### PR TITLE
[개선] SearchInput 호출 코드 개선

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
@@ -58,62 +58,66 @@ final class SearchInputViewController: UIViewController {
             $0.height.equalTo(40)
         }
         
-        let searchBarView2 = DealiSearchInput(defaultKeyword: "원피스", placeholderText: "상품을 검색해주세요.", delegate: self)
+        let searchBarView2 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarView2)
         searchBarView2.then {
-            $0.backgroundColor = .clear
+            $0.keyword = "원피스"
+            $0.placeholder = "상품을 검색해주세요."
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
         
-        let searchBarView3 = DealiSearchInput(defaultKeyword: "원피스", placeholderText: "상품을 검색해주세요.", resetKeywordWhenClearTapped: false, delegate: self)
+        let searchBarView3 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarView3)
         searchBarView3.then {
-            $0.backgroundColor = .clear
+            $0.keyword = "원피스"
+            $0.placeholder = "상품을 검색해주세요."
+            $0.resetKeywordWhenClearTapped = false
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
         
-        searchBarView3.updateKeyword("키워드 변경")
+        searchBarView3.updateKeyword("clear 버튼 disable 기능 테스트")
         
-        let searchBarView4 = DealiSearchInput(placeholderText: "상품을 검색해주세요.", delegate: self)
+        let searchBarView4 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarView4)
         searchBarView4.then {
             $0.backgroundColor = .clear
+            $0.placeholder = "keyboard AccessoryView test"
             $0.keyboardCloseButtonString = "닫기"
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
         
-        let searchBarSubCategoryView1 = DealiSearchInput(type: .subCategory(keyword: "아우터"), delegate: self)
+        let searchBarSubCategoryView1 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarSubCategoryView1)
         searchBarSubCategoryView1.then {
             $0.backgroundColor = .clear
+            $0.subKeyword = "아우터"
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
         
-        let searchBarSubCategoryView2 = DealiSearchInput(type: .subCategory(keyword: "아우터"), defaultKeyword: "패딩", delegate: self)
+        let searchBarSubCategoryView2 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarSubCategoryView2)
         searchBarSubCategoryView2.then {
             $0.backgroundColor = .clear
+            $0.keyword = "패딩"
+            $0.subKeyword = "아우터"
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
         
-        let searchBarSubCategoryView3 = DealiSearchInput(
-            type: .subCategory(keyword: "키워드가 들어가는데 엄청길어요")
-            , placeholderText: "상품을 검색해주세요."
-            , delegate: self
-        )
+        let searchBarSubCategoryView3 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarSubCategoryView3)
         searchBarSubCategoryView3.then {
-            $0.backgroundColor = .clear
+            $0.subKeyword = "키워드가 들어가는데 엄청길어요"
+            $0.placeholder = "상품을 검색해주세요."
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -149,13 +149,15 @@ public final class DealiSearchInput: UIView {
     }
     
     // MARK: - Initializer
-    public init(delegate: DealiSearchInputDelegate?) {
-        self.delegate = delegate
+    public init(keyword: String = "", placeholder: String = "", delegate: DealiSearchInputDelegate?) {
         super.init(frame: .zero)
         setContainerStackView()
         setTextField()
         setSearchStatusImage()
-        updateKeyword(self.keyword)
+        
+        self.keyword = keyword
+        self.placeholder = placeholder
+        self.delegate = delegate
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -26,7 +26,7 @@ public protocol DealiSearchInputDelegate: AnyObject {
 public final class DealiSearchInput: UIView {
     
     // MARK: Enum Types
-    public enum SearchInputType: Equatable {
+    private enum SearchInputType: Equatable {
         case `default`
         case subKeyword
     }

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -149,7 +149,7 @@ public final class DealiSearchInput: UIView {
     }
     
     // MARK: - Initializer
-    public init(delegate: DealiSearchInputDelegate? = nil) {
+    public init(delegate: DealiSearchInputDelegate?) {
         self.delegate = delegate
         super.init(frame: .zero)
         setContainerStackView()


### PR DESCRIPTION
## PR 마감기한
필터 서치인풋 개선작업에 포함되길 희망합니다. 
필터 코드의 전반적인 개선 전에 반영되면 좋을 것 같아 오픈합니다. 

## 작업 내용
- 필터 작업하다보니 생각보다 케이스가 많이 생겨서 init으로 처리하기엔 너무 무겁다는 생각이 들었습니다. 
다른 컴포넌트와 동일하게 then에서 처리 가능하도록 수정하였습니다. (단, delegate는 아마 필수로 사용할것이라 예상되어서 제외)
- 생략가능한 코드 개선
- 네이밍 및 주석 수정 등

## Merge 전 필요한 작업
- SearchInput 사용하는 페이지가 AS-IS와 동일하게 동작하는지 테스트

## 주의해서 봐야 할 부분
- 이렇게 하는 것이 좋을까요?
- 문제 없는지 테스트 해주세요
