### PR TITLE
[MP-4064] SearchInput 서브키워드 최대 너비 수정

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
@@ -116,7 +116,7 @@ final class SearchInputViewController: UIViewController {
         let searchBarSubCategoryView3 = DealiSearchInput(delegate: self)
         contentStackView.addArrangedSubview(searchBarSubCategoryView3)
         searchBarSubCategoryView3.then {
-            $0.subKeyword = "키워드가 들어가는데 엄청길어요"
+            $0.subKeyword = "abcdefghijk"
             $0.placeholder = "상품을 검색해주세요."
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/SearchInputViewController.swift
@@ -122,6 +122,8 @@ final class SearchInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
         }
+        
+        searchBarSubCategoryView3.updateSubKeyword("ChangeKeyword")
     }
 }
 

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -260,7 +260,9 @@ extension DealiSearchInput {
     }
     
     private func setSubKeywordView(with keyword: String) {
-        if subKeywordLabel == nil {
+        if let subKeywordLabel {
+            subKeywordLabel.text = keyword
+        } else {
             let keywordView = UIView()
             stackView.insertArrangedSubview(keywordView, at: 0)
             keywordView.then {
@@ -286,7 +288,7 @@ extension DealiSearchInput {
                 $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
             }.snp.makeConstraints {
                 $0.top.bottom.equalToSuperview().inset(4)
-                $0.leading.trailing.equalToSuperview().inset(8)
+                $0.left.right.equalToSuperview().inset(8)
                 $0.centerX.equalToSuperview()
             }
             
@@ -296,8 +298,6 @@ extension DealiSearchInput {
             }
             
             subKeywordLabel = keywordLabel
-        } else {
-            subKeywordLabel?.text = keyword
         }
     }
     

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -302,12 +302,14 @@ extension DealiSearchInput {
     }
     
     private func setSearchBarAs(status: SearchStatus) {
+        searchImageView.isUserInteractionEnabled = true
         switch inputType {
         case .default:
             searchImageView.image = status.image
         case .subKeyword:
             switch status {
             case .empty:
+                searchImageView.isUserInteractionEnabled = false
                 searchImageView.image = nil
             case .editing:
                 searchImageView.image = status.image

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -83,6 +83,7 @@ public final class DealiSearchInput: UIView {
     private let placeHolderLabel = UILabel()
     private let searchTextField = UITextField()
     private let searchImageView = UIImageView()
+    private var subKeywordLabel: UILabel?
     private var inputType: SearchInputType = .default {
         didSet {
             self.updateKeyword(keyword)
@@ -176,6 +177,11 @@ public final class DealiSearchInput: UIView {
         searchTextField.text = keyword
         setSearchBarAs(status: .editing)
     }
+    
+    public func updateSubKeyword(_ keyword: String?) {
+        guard let keyword, !keyword.isEmpty else { return }
+        setSubKeywordView(with: keyword)
+    }
 }
 
 // MARK: - Setup
@@ -254,38 +260,44 @@ extension DealiSearchInput {
     }
     
     private func setSubKeywordView(with keyword: String) {
-        let keywordView = UIView()
-        stackView.insertArrangedSubview(keywordView, at: 0)
-        keywordView.then {
-            $0.backgroundColor = SubKeywordViewConsants.backgroundColor
-            $0.setCornerRadius(
-                SubKeywordViewConsants.radius
-                , borderWidth: SubKeywordViewConsants.borderWidth
-                , borderColor: SubKeywordViewConsants.borderColor
-            )
-            $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        }.snp.makeConstraints {
-            $0.width.lessThanOrEqualTo(SubKeywordViewConsants.maxWidth)
-        }
-        
-        let keywordLabel = UILabel()
-        keywordView.addSubview(keywordLabel)
-        keywordLabel.then {
-            $0.textColor = SubKeywordViewConsants.textColor
-            $0.font = SubKeywordViewConsants.font
-            $0.textAlignment = .center
-            $0.lineBreakMode = .byTruncatingTail
-            $0.text = keyword
-            $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        }.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview().inset(4)
-            $0.leading.trailing.equalToSuperview().inset(8)
-            $0.centerX.equalToSuperview()
-        }
-        
-        stackView.setCustomSpacing(8, after: keywordView)
-        stackView.do {
-            $0.layoutMargins.left = StackViewConstants.layoutVMargin
+        if subKeywordLabel == nil {
+            let keywordView = UIView()
+            stackView.insertArrangedSubview(keywordView, at: 0)
+            keywordView.then {
+                $0.backgroundColor = SubKeywordViewConsants.backgroundColor
+                $0.setCornerRadius(
+                    SubKeywordViewConsants.radius
+                    , borderWidth: SubKeywordViewConsants.borderWidth
+                    , borderColor: SubKeywordViewConsants.borderColor
+                )
+                $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            }.snp.makeConstraints {
+                $0.width.lessThanOrEqualTo(SubKeywordViewConsants.maxWidth)
+            }
+            
+            let keywordLabel = UILabel()
+            keywordView.addSubview(keywordLabel)
+            keywordLabel.then {
+                $0.textColor = SubKeywordViewConsants.textColor
+                $0.font = SubKeywordViewConsants.font
+                $0.textAlignment = .center
+                $0.lineBreakMode = .byTruncatingTail
+                $0.text = keyword
+                $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            }.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(4)
+                $0.leading.trailing.equalToSuperview().inset(8)
+                $0.centerX.equalToSuperview()
+            }
+            
+            stackView.setCustomSpacing(8, after: keywordView)
+            stackView.do {
+                $0.layoutMargins.left = StackViewConstants.layoutVMargin
+            }
+            
+            subKeywordLabel = keywordLabel
+        } else {
+            subKeywordLabel?.text = keyword
         }
     }
     

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -73,7 +73,7 @@ public final class DealiSearchInput: UIView {
         static let radius: CGFloat = 6
         static let borderColor: UIColor = DealiColor.g20
         static let borderWidth: CGFloat = 1
-        static let maxWidth: CGFloat = 80
+        static let maxWidth: CGFloat = 88
         static let textColor: UIColor = DealiColor.g80
         static let font: UIFont = .systemFont(ofSize: 14, weight: .bold)
     }


### PR DESCRIPTION
## PR 마감기한
2024-02-15

## 작업 내용
- SearchInput 서브 키워드 너비 수정
AS-IS : 80
TO-BE: 88
    <details>
    <summary> 디자인가이드 스크린샷 </summary>
    <img width="560" alt="스크린샷 2024-01-19 오후 3 32 08" src="https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/33b1cd5f-323f-4591-817e-c0802bee4951">
    </details>

<br>

- 서브키워드 텍스트 업데이트 기능 추가
소매 내 상품 스크린에서 선택하는 폴더에 따라 서브키워드 변경 필요해서 추가하였습니다.
    <details>
    <summary> 디자인가이드 스크린샷 </summary>
    <img width="672" alt="스크린샷 2024-01-19 오후 4 46 10" src="https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/af05c62c-0710-484c-9159-7f5eb619d867">
    </details>

- Clear버튼 미노출 시 영역 UserInteractionEnabled false
이미지만 비어있어 클릭 이벤트가 발생하는 케이스 방지