### PR TITLE
[필터 3차] TextInputV2 우측 뷰 Clear 타입 추가

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/TextInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/TextInputViewController.swift
@@ -68,6 +68,7 @@ final class TextInputViewController: UIViewController {
             let button = DealiControl.btnOutlineMedium01()
             button.title = "Default"
             $0.actionButton = button
+            $0.inputRightViewType = .clear
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
         }

--- a/Sources/DealiDesignKit/Components/TextInputs/DealiTextInputEnum.swift
+++ b/Sources/DealiDesignKit/Components/TextInputs/DealiTextInputEnum.swift
@@ -18,8 +18,7 @@ public enum ETextInputStatus: Equatable {
 
 public enum ETextInputRightViewType {
     case none
-    case success
-    case failure
+    case clear
     case timer
     case custom(_ image: UIImage?)
 }

--- a/Sources/DealiDesignKit/Components/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextInputs/DealiTextInput_v2.swift
@@ -124,6 +124,14 @@ public final class DealiTextInput_v2: UIView {
                 if let actionButton = self.actionButton {
                     actionButton.isEnabled = !(self.inputStatus == .disabled)
                 }
+                
+                switch self.inputRightViewType {
+                case .clear:
+                    self.textInputRightImageView.isHidden = self.inputStatus != .focusIn
+                    self.textInputRightImageView.image = UIImage(named: "ic_x")
+                default:
+                    self.textInputRightImageView.isHidden = true
+                }
             }
         }
     }
@@ -153,6 +161,9 @@ public final class DealiTextInput_v2: UIView {
             }.disposed(by: self.disposeBag)
         }
     }
+    
+    /// TextInput RightView 타입 세팅
+    public var inputRightViewType: ETextInputRightViewType = .none
     
     public init() {
         super.init(frame: .zero)
@@ -247,7 +258,6 @@ public final class DealiTextInput_v2: UIView {
         
         textFieldContentStackView.addArrangedSubview(self.textInputRightImageView)
         self.textInputRightImageView.then {
-            $0.backgroundColor = .red
             $0.isHidden = true
         }.snp.makeConstraints {
             $0.size.equalTo(CGSize(width: 16.0, height: 16.0))
@@ -305,6 +315,19 @@ public final class DealiTextInput_v2: UIView {
                     let price = Int(text.replacingOccurrences(of: ",", with: ""))
                 {
                     owner.textField.text = price.commaString()
+                }
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.textInputRightImageView.rx.tapGestureOnTop()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self else { return }
+                switch self.inputRightViewType {
+                case .clear:
+                    self.text = nil
+                default:
+                    return
                 }
             })
             .disposed(by: self.disposeBag)

--- a/Sources/DealiDesignKit/Components/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextInputs/DealiTextInput_v2.swift
@@ -23,6 +23,7 @@ public final class DealiTextInput_v2: UIView {
     private let textInputRightImageView = UIImageView()
     
     public var textFieldDidEndEditing: Driver<Bool>!
+    public var textFieldShouldReturn: Driver<Bool>!
     
     private let disposeBag = DisposeBag()
     
@@ -284,14 +285,13 @@ public final class DealiTextInput_v2: UIView {
     }
     
     private func RX() {
-        self.textFieldDidEndEditing = Driver.merge(
-            self.textField.rx.controlEvent(.editingDidEndOnExit)
-                .map { true }
-                .asDriver(onErrorJustReturn: false),
-            self.textField.rx.controlEvent(.editingDidEnd)
-                .map { true }
-                .asDriver(onErrorJustReturn: false)
-        )
+        self.textFieldDidEndEditing = self.textField.rx.controlEvent(.editingDidEnd)
+            .map { true }
+            .asDriver(onErrorJustReturn: false)
+        
+        self.textFieldShouldReturn = self.textField.rx.controlEvent(.editingDidEndOnExit)
+            .map { true }
+            .asDriver(onErrorJustReturn: false)
         
         self.textField.rx.controlEvent(.editingDidBegin).asSignal().emit(with: self) { owner, _ in
             self.inputStatus = .focusIn


### PR DESCRIPTION
- 필터 3차에 TextInput X버튼이 필요해 해당 타입에 한하여 추가하였습니다. 
- controlEvent 분리 및 shouldReturn 추가
![IMG_8BC1896D6BEB-1](https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/c3b16c79-1e4a-482b-8b92-2c0a3041fc5e)
