### PR TITLE
탭바 Divider뷰 위치 수정, 스크롤 포지션 관련 조건 수정

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
@@ -132,7 +132,7 @@ final class TabBarComponentrViewController: UIViewController {
         
         contentStackView.addArrangedSubview(self.tabBarViewShort)
         self.tabBarViewShort.then {
-            $0.setTabbarItems(tabbarItemArray: segmentTabBarItemArray, startIndex: 4)
+            $0.setTabbarItems(tabbarItemArray: segmentTabBarItemArray)
             $0.delegate = self
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
@@ -152,6 +152,7 @@ final class TabBarComponentrViewController: UIViewController {
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
         }
+        self.tabBarView04.setSelectedIndex(index: 8)
         
         let titleLabel05 = UILabel()
         contentStackView.addArrangedSubview(titleLabel05)

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
@@ -74,13 +74,14 @@ final class TabBarComponentrViewController: UIViewController {
             $0.alignment = .center
             $0.distribution = .equalSpacing
         }.snp.makeConstraints {
-            $0.top.bottom.left.right.equalToSuperview()
+            $0.top.equalToSuperview().offset(10)
+            $0.bottom.left.right.equalToSuperview()
         }
         
         let titleLabel01 = UILabel()
         contentStackView.addArrangedSubview(titleLabel01)
         titleLabel01.do {
-            $0.text = "tabBarView01"
+            $0.text = "tabBarSegment01"
             $0.font = .b1sb15
         }
         
@@ -95,7 +96,7 @@ final class TabBarComponentrViewController: UIViewController {
         let titleLabel02 = UILabel()
         contentStackView.addArrangedSubview(titleLabel02)
         titleLabel02.do {
-            $0.text = "tabBarView02"
+            $0.text = "tabBarSlider01"
             $0.font = .b1sb15
         }
         
@@ -110,7 +111,7 @@ final class TabBarComponentrViewController: UIViewController {
         let titleLabel03 = UILabel()
         contentStackView.addArrangedSubview(titleLabel03)
         titleLabel03.do {
-            $0.text = "tabBarView03"
+            $0.text = "tabBarSlider02"
             $0.font = .b1sb15
         }
         
@@ -125,7 +126,7 @@ final class TabBarComponentrViewController: UIViewController {
         let titleLabel07 = UILabel()
         contentStackView.addArrangedSubview(titleLabel07)
         titleLabel07.do {
-            $0.text = "tabBarView03 - Short"
+            $0.text = "tabBarSlider02 - Short"
             $0.font = .b1sb15
         }
         
@@ -140,7 +141,7 @@ final class TabBarComponentrViewController: UIViewController {
         let titleLabel04 = UILabel()
         contentStackView.addArrangedSubview(titleLabel04)
         titleLabel04.do {
-            $0.text = "tabBarView04"
+            $0.text = "tabBarChip01"
             $0.font = .b1sb15
         }
         
@@ -155,7 +156,7 @@ final class TabBarComponentrViewController: UIViewController {
         let titleLabel05 = UILabel()
         contentStackView.addArrangedSubview(titleLabel05)
         titleLabel05.do {
-            $0.text = "tabBarView05"
+            $0.text = "tabBarSlider03"
             $0.font = .b1sb15
         }
         

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
@@ -132,7 +132,7 @@ final class TabBarComponentrViewController: UIViewController {
         
         contentStackView.addArrangedSubview(self.tabBarViewShort)
         self.tabBarViewShort.then {
-            $0.setTabbarItems(tabbarItemArray: segmentTabBarItemArray)
+            $0.setTabbarItems(tabbarItemArray: segmentTabBarItemArray, startIndex: 4)
             $0.delegate = self
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TabBarComponentrViewController.swift
@@ -30,6 +30,7 @@ final class TabBarComponentrViewController: UIViewController {
     private let tabBarView01 = DealiTabBar.tabBarSegment01()
     private let tabBarView02 = DealiTabBar.tabBarSlider01()
     private let tabBarView03 = DealiTabBar.tabBarSlider02()
+    private let tabBarViewShort = DealiTabBar.tabBarSlider02()
     private let tabBarView04 = DealiTabBar.tabBarChip01()
     private let tabBarView05 = DealiTabBar.tabBarSlider03()
     
@@ -76,6 +77,12 @@ final class TabBarComponentrViewController: UIViewController {
             $0.top.bottom.left.right.equalToSuperview()
         }
         
+        let titleLabel01 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel01)
+        titleLabel01.do {
+            $0.text = "tabBarView01"
+            $0.font = .b1sb15
+        }
         
         contentStackView.addArrangedSubview(self.tabBarView01)
         self.tabBarView01.then {
@@ -83,6 +90,13 @@ final class TabBarComponentrViewController: UIViewController {
             $0.delegate = self
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
+        }
+        
+        let titleLabel02 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel02)
+        titleLabel02.do {
+            $0.text = "tabBarView02"
+            $0.font = .b1sb15
         }
         
         contentStackView.addArrangedSubview(self.tabBarView02)
@@ -93,12 +107,41 @@ final class TabBarComponentrViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
+        let titleLabel03 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel03)
+        titleLabel03.do {
+            $0.text = "tabBarView03"
+            $0.font = .b1sb15
+        }
+        
         contentStackView.addArrangedSubview(self.tabBarView03)
         self.tabBarView03.then {
             $0.setTabbarItems(tabbarItemArray: sliderTabBarItemArray)
             $0.delegate = self
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
+        }
+        
+        let titleLabel07 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel07)
+        titleLabel07.do {
+            $0.text = "tabBarView03 - Short"
+            $0.font = .b1sb15
+        }
+        
+        contentStackView.addArrangedSubview(self.tabBarViewShort)
+        self.tabBarViewShort.then {
+            $0.setTabbarItems(tabbarItemArray: segmentTabBarItemArray)
+            $0.delegate = self
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+        
+        let titleLabel04 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel04)
+        titleLabel04.do {
+            $0.text = "tabBarView04"
+            $0.font = .b1sb15
         }
         
         contentStackView.addArrangedSubview(self.tabBarView04)
@@ -109,12 +152,26 @@ final class TabBarComponentrViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
+        let titleLabel05 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel05)
+        titleLabel05.do {
+            $0.text = "tabBarView05"
+            $0.font = .b1sb15
+        }
+        
         contentStackView.addArrangedSubview(self.tabBarView05)
         self.tabBarView05.then {
             $0.setTabbarItems(tabbarItemArray: sliderTabBarItemArray)
             $0.delegate = self
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
+        }
+        
+        let titleLabel06 = UILabel()
+        contentStackView.addArrangedSubview(titleLabel06)
+        titleLabel06.do {
+            $0.text = "badgeOnOffButton"
+            $0.font = .b1sb15
         }
         
         contentStackView.addArrangedSubview(self.badgeOnOffButton)

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -380,13 +380,13 @@ final public class DealiTabBarView: UIView {
         var offset: CGFloat = -1
 
         if case .sliderChip(_) = self.preset.style {
-            if positionX < self.contentScrollView.contentOffset.x || self.contentScrollView.contentOffset.x <= 0 {
+            if positionX < self.contentScrollView.contentOffset.x || self.contentScrollView.frame.width <= 0 {
                 offset = positionX
             } else if (positionX + contentWidth) > self.contentScrollView.contentOffset.x + self.contentScrollView.frame.width {
                 offset = (positionX + contentWidth) - self.contentScrollView.frame.width
             }
         } else {
-            if (positionX - self.preset.contentButtonPadding) < self.contentScrollView.contentOffset.x || self.contentScrollView.contentOffset.x <= 0 {
+            if (positionX - self.preset.contentButtonPadding) < self.contentScrollView.contentOffset.x || self.contentScrollView.frame.width <= 0 {
                 offset = (positionX - self.preset.contentButtonPadding)
             } else if (positionX + contentWidth + self.preset.contentButtonPadding) > self.contentScrollView.contentOffset.x + self.contentScrollView.frame.width {
                 offset = (positionX + contentWidth + self.preset.contentButtonPadding) - self.contentScrollView.frame.width

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -201,7 +201,6 @@ final public class DealiTabBarView: UIView {
         
         /// 가려지는 tabbar item이 있다면 해당 아이템을 제외하고 tabbarView를 재구성
         let itemArray = tabbarItemArray.filter({ $0.isHidden == false })
-        self.setSelectedIndexWithScroll(index: startIndex)
         
         let offset = self.contentScrollView.contentOffset
         
@@ -267,7 +266,7 @@ final public class DealiTabBarView: UIView {
         self.updateTabbarItemInfo()
         
         self.contentScrollView.setContentOffset((maintainContentOffset ? offset : .zero), animated: false)
-        
+        self.setSelectedIndexWithScroll(index: startIndex)
     }
     
     /// 특정 index에 위치한 tabbaritem의 title 변경 처리

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -386,7 +386,7 @@ final public class DealiTabBarView: UIView {
                 offset = (positionX + contentWidth) - self.contentScrollView.frame.width
             }
         } else {
-            if (positionX - self.preset.contentButtonPadding) < self.contentScrollView.contentOffset.x {
+            if (positionX - self.preset.contentButtonPadding) < self.contentScrollView.contentOffset.x || self.contentScrollView.contentOffset.x <= 0 {
                 offset = (positionX - self.preset.contentButtonPadding)
             } else if (positionX + contentWidth + self.preset.contentButtonPadding) > self.contentScrollView.contentOffset.x + self.contentScrollView.frame.width {
                 offset = (positionX + contentWidth + self.preset.contentButtonPadding) - self.contentScrollView.frame.width

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -120,8 +120,9 @@ final public class DealiTabBarView: UIView {
                 $0.top.bottom.left.right.equalToSuperview()
             }
             
-            self.contentScrollView.addSubview(self.bottomDividerView)
+            self.addSubview(self.bottomDividerView)
             self.contentScrollView.addSubview(self.selectedUnderLineImageView)
+            self.bringSubviewToFront(self.contentScrollView)
         }
         
         self.bottomDividerView.then {

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -162,12 +162,9 @@ final public class DealiTabBarView: UIView {
         self.setSelectedIndex(index: sender.tag, animated: true)
     }
     
-    public func setSelectedIndex(index: Int, animated: Bool = false) {
+    private func setSelectedIndexWithScroll(index: Int) {
         guard index < self.tabbarItemInfoArray.count else { return }
         self.selectedIndex = index
-        
-        /// tabbar Item button 클릭으로 이벤트 발생시 선택된 Button의 index값을 didSelectTabBarIndex를 통해 전달
-        self.delegate?.didSelectTabBar(self, selectedIndex: self.selectedIndex, showScrollAnimation: animated)
         
         /// chip을 사용하는 tabbar에서는 따로 underLine 표시되지않기 때문에 chip이 아닌 경우에만 값을 세팅하도록 처리
         if self.preset.style == .segment || self.preset.style == .sliderButton {
@@ -181,6 +178,12 @@ final public class DealiTabBarView: UIView {
         if self.preset.style != .segment && self.isStandAloneView {
             self.moveScrollContentOffset(positionX: self.tabbarItemInfoArray[index].contentStartPositionX, contentWidth: self.tabbarItemInfoArray[index].contentWidth)
         }
+    }
+    
+    public func setSelectedIndex(index: Int, animated: Bool = false) {
+        self.setSelectedIndexWithScroll(index: index)
+        /// tabbar Item button 클릭으로 이벤트 발생시 선택된 Button의 index값을 didSelectTabBarIndex를 통해 전달
+        self.delegate?.didSelectTabBar(self, selectedIndex: self.selectedIndex, showScrollAnimation: animated)
     }
     
     /// Tabbar를 다시 구성하거나할때 기존 tabbar의 정보를 초기화
@@ -198,11 +201,7 @@ final public class DealiTabBarView: UIView {
         
         /// 가려지는 tabbar item이 있다면 해당 아이템을 제외하고 tabbarView를 재구성
         let itemArray = tabbarItemArray.filter({ $0.isHidden == false })
-        
-        self.selectedIndex = startIndex
-        if self.selectedIndex >= itemArray.count {
-            self.selectedIndex = (itemArray.count - 1)
-        }
+        self.setSelectedIndexWithScroll(index: startIndex)
         
         let offset = self.contentScrollView.contentOffset
         

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -194,11 +194,12 @@ final public class DealiTabBarView: UIView {
     }
     
     /// tabbar를 구성할 정보를 받아 Tabbar Item Button 생성 및 정보 저장
-    public func setTabbarItems(tabbarItemArray: [DealiTabBarItem], maintainContentOffset: Bool = true) {
+    public func setTabbarItems(tabbarItemArray: [DealiTabBarItem], maintainContentOffset: Bool = true, startIndex: Int = 0) {
         
         /// 가려지는 tabbar item이 있다면 해당 아이템을 제외하고 tabbarView를 재구성
         let itemArray = tabbarItemArray.filter({ $0.isHidden == false })
         
+        self.selectedIndex = startIndex
         if self.selectedIndex >= itemArray.count {
             self.selectedIndex = (itemArray.count - 1)
         }

--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -380,7 +380,7 @@ final public class DealiTabBarView: UIView {
         var offset: CGFloat = -1
 
         if case .sliderChip(_) = self.preset.style {
-            if positionX < self.contentScrollView.contentOffset.x {
+            if positionX < self.contentScrollView.contentOffset.x || self.contentScrollView.contentOffset.x <= 0 {
                 offset = positionX
             } else if (positionX + contentWidth) > self.contentScrollView.contentOffset.x + self.contentScrollView.frame.width {
                 offset = (positionX + contentWidth) - self.contentScrollView.frame.width
@@ -394,7 +394,7 @@ final public class DealiTabBarView: UIView {
         }
 
         if offset >= 0 {
-            self.contentScrollView.setContentOffset(CGPoint(x: offset, y: self.contentScrollView.contentOffset.y), animated: false)
+            self.contentScrollView.setContentOffset(CGPoint(x: offset, y: self.contentScrollView.contentOffset.y), animated: true)
         }
     }
 }


### PR DESCRIPTION
- 탭바 Divider 뷰 위치 수정
    - 탭바 Divider가 contentScrollView만큼만 노출되서, 스크롤이 화면 너비보다 작은 케이스에 Divider 미노출영역 생김
    - 짧은 탭바에도 Divider View 모두 노출되도록 수정
- contentScrollView offset 조건 수정
    -  프로덕트에서 화면이 모두 그려지기 전에 setSelectedIndex로 탭바 아이템을 선택하면 스크롤 포지션이 올바르게 위치하지 않음
    (contentScrollView.frame이 0이라 else 조건에 걸려 탭이 가려지는 위치로 이동됨)
    - frame이 0인 경우에도 offset을 올바르게 이동하도록 수정 
- 탭바 클릭으로 offset 조정 시 애니메이션 추가
- 탭바 명칭이 헷갈려서 라벨 추가
- 탭바 세팅 시 startIndex를 추가하여 didSelect delegate 이벤트가 호출되지 않도록 하였습니다.
(Cell에서 단독 사용 시 setSelectedIndex를 사용해서 시작 포지션을 지정하는 경우 cell이 재사용되면서 이벤트가 계속 호출되어서 초기 셑팅과 분리가 필요한 사유)

![IMG_0028](https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/4db72c24-20f6-40fe-ba60-5770734b8368)
