### PR TITLE
slider thumb 노출 우선순위 지정, SearchInput 수정 반영

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/SearchInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/SearchInputViewController.swift
@@ -63,6 +63,7 @@ final class SearchInputViewController: UIViewController {
         searchBarView2.then {
             $0.keyword = "원피스"
             $0.placeholder = "상품을 검색해주세요."
+            $0.shouldFixStatusOnFirst = true
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)
@@ -97,6 +98,7 @@ final class SearchInputViewController: UIViewController {
         searchBarSubCategoryView1.then {
             $0.backgroundColor = .clear
             $0.subKeyword = "아우터"
+            $0.shouldFixStatusOnFirst = true
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
             $0.height.equalTo(40)

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -169,13 +169,11 @@ public final class DealiSearchInput: UIView {
     public func updateKeyword(_ keyword: String?) {
         guard let keyword, !keyword.isEmpty else {
             searchTextField.text = nil
-            if !searchTextField.isEditing {
-                setSearchBarAs(status: .default)
-            }
+            setSearchBarAs(status: searchTextField.isEditing ? .editing : .default)
             return
         }
         searchTextField.text = keyword
-        setSearchBarAs(status: .editing)
+        setSearchBarAs(status: searchTextField.isEditing ? .editing : .default)
     }
     
     public func updateSubKeyword(_ keyword: String?) {
@@ -316,7 +314,8 @@ extension DealiSearchInput {
     }
     
     private func setSearchBarAs(status: SearchStatus) {
-        clearImageView.isHidden = status != .editing
+        clearImageView.isHidden = searchTextField.text?.isEmpty == true && status != .editing
+        searchImageView.isHidden = searchTextField.text?.isEmpty == false && status != .editing
         placeHolderLabel.isHidden = searchTextField.text?.isEmpty == false
     }
     

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -80,7 +80,7 @@ public final class DealiSearchInput: UIView {
     private var subKeywordLabel: UILabel?
     private var inputType: SearchInputType = .default {
         didSet {
-            self.updateKeyword(keyword)
+            self.updateKeyword(keyword, isInputTypeUpdate: true)
         }
     }
     private weak var delegate: DealiSearchInputDelegate?
@@ -121,6 +121,8 @@ public final class DealiSearchInput: UIView {
     
     /// clear 버튼 탭 시 텍스트 초기화. false인 경우  동작없음
     public var resetKeywordWhenClearTapped: Bool = true
+    // InputType이 지정될때의 초기 키워드 상태에 따라 status ui 고정 여부 결정
+    public var shouldFixStatusOnFirst: Bool = false
     
     /// 키보드 닫기 String을 받을경우에만 해당 버튼이 추가되도록 작업
     public var keyboardCloseButtonString: String? {
@@ -166,14 +168,14 @@ public final class DealiSearchInput: UIView {
     }
     
     // MARK: Functions
-    public func updateKeyword(_ keyword: String?) {
+    public func updateKeyword(_ keyword: String?, isInputTypeUpdate: Bool = false) {
         guard let keyword, !keyword.isEmpty else {
             searchTextField.text = nil
-            setSearchBarAs(status: searchTextField.isEditing ? .editing : .default)
+            setSearchBarAs(status: searchTextField.isEditing ? .editing : .default, isInputTypeUpdate: isInputTypeUpdate)
             return
         }
         searchTextField.text = keyword
-        setSearchBarAs(status: searchTextField.isEditing ? .editing : .default)
+        setSearchBarAs(status: searchTextField.isEditing ? .editing : .default, isInputTypeUpdate: isInputTypeUpdate)
     }
     
     public func updateSubKeyword(_ keyword: String?) {
@@ -313,7 +315,8 @@ extension DealiSearchInput {
         }
     }
     
-    private func setSearchBarAs(status: SearchStatus) {
+    private func setSearchBarAs(status: SearchStatus, isInputTypeUpdate: Bool = false) {
+        if shouldFixStatusOnFirst && !isInputTypeUpdate { return }
         clearImageView.isHidden = searchTextField.text?.isEmpty == true && status != .editing
         searchImageView.isHidden = searchTextField.text?.isEmpty == false && status != .editing
         placeHolderLabel.isHidden = searchTextField.text?.isEmpty == false

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -32,15 +32,8 @@ public final class DealiSearchInput: UIView {
     }
     
     private enum SearchStatus {
-        case empty
+        case `default`
         case editing
-        
-        var image: UIImage? {
-            switch self {
-            case .empty: return Constants.imageSearch
-            case .editing: return Constants.imageClear
-            }
-        }
     }
     
     // MARK: - Constants
@@ -82,6 +75,7 @@ public final class DealiSearchInput: UIView {
     private let stackView = UIStackView()
     private let placeHolderLabel = UILabel()
     private let searchTextField = UITextField()
+    private let clearImageView = UIImageView()
     private let searchImageView = UIImageView()
     private var subKeywordLabel: UILabel?
     private var inputType: SearchInputType = .default {
@@ -176,7 +170,7 @@ public final class DealiSearchInput: UIView {
         guard let keyword, !keyword.isEmpty else {
             searchTextField.text = nil
             if !searchTextField.isEditing {
-                setSearchBarAs(status: .empty)
+                setSearchBarAs(status: .default)
             }
             return
         }
@@ -251,15 +245,26 @@ extension DealiSearchInput {
     }
     
     private func setSearchStatusImage() {
+        stackView.addArrangedSubview(clearImageView)
+        clearImageView.then {
+            $0.contentMode = .scaleAspectFit
+            $0.isUserInteractionEnabled = true
+            $0.image = Constants.imageClear
+        }.snp.makeConstraints {
+            $0.width.equalTo(Constants.imageClearSize)
+        }
+        stackView.setCustomSpacing(12, after: clearImageView)
+        
         stackView.addArrangedSubview(searchImageView)
         searchImageView.then {
             $0.contentMode = .scaleAspectFit
-            $0.isUserInteractionEnabled = true
+            $0.isUserInteractionEnabled = false
+            $0.image = Constants.imageSearch
         }.snp.makeConstraints {
             $0.width.equalTo(Constants.imageSearchSize)
         }
         
-        searchImageView.rx.tapGestureOnTop()
+        clearImageView.rx.tapGestureOnTop()
             .when(.recognized)
             .subscribe(onNext: { [weak self] _ in
                 guard let self else { return }
@@ -311,29 +316,8 @@ extension DealiSearchInput {
     }
     
     private func setSearchBarAs(status: SearchStatus) {
-        switch inputType {
-        case .default:
-            searchImageView.image = status.image
-        case .subKeyword:
-            switch status {
-            case .empty:
-                searchImageView.image = nil
-            case .editing:
-                searchImageView.image = status.image
-            }
-        }
-        
-        if status == .editing {
-            searchImageView.snp.updateConstraints {
-                $0.width.equalTo(Constants.imageClearSize)
-            }
-        } else {
-            searchImageView.snp.updateConstraints {
-                $0.width.equalTo(Constants.imageSearchSize)
-            }
-        }
-        
-        placeHolderLabel.isHidden = (status == .editing && searchTextField.text?.isEmpty == false)
+        clearImageView.isHidden = status != .editing
+        placeHolderLabel.isHidden = searchTextField.text?.isEmpty == false
     }
     
     // MARK: Rx Setup
@@ -362,9 +346,7 @@ extension DealiSearchInput {
         guard searchTextField.text != nil, searchTextField.text?.isEmpty == false else { return }
         if resetKeywordWhenClearTapped {
             searchTextField.text = nil
-            if !searchTextField.isEditing {
-                setSearchBarAs(status: .empty)
-            }
+            setSearchBarAs(status: searchTextField.isEditing ? .editing : .default)
         }
         delegate?.clear()
     }
@@ -376,7 +358,7 @@ extension DealiSearchInput {
     
     private func textFieldShouldReturn(_ textField: UITextField) {
         textField.resignFirstResponder()
-        setSearchBarAs(status: textField.text?.isEmpty == true ? .empty : .editing)
+        setSearchBarAs(status: .default)
         delegate?.search(keyword: textField.text)
     }
     
@@ -386,7 +368,7 @@ extension DealiSearchInput {
     }
     
     private func textFieldEditingDidEnd(_ textField: UITextField) {
-        setSearchBarAs(status: textField.text?.isEmpty == true ? .empty : .editing)
+        setSearchBarAs(status: .default)
         delegate?.endEditing()
     }
     

--- a/Sources/DealiDesignKit/Components/SliderBar/DealiSliderBar.swift
+++ b/Sources/DealiDesignKit/Components/SliderBar/DealiSliderBar.swift
@@ -59,6 +59,11 @@ public final class DealiSliderBar: UIControl {
         self.minThumbView.snp.updateConstraints {
             $0.centerX.equalTo(self.barView.snp.left).offset(leftThumbLastOffset)
         }
+        
+        // 최댓값과 동일
+        if ratio == 1 && self.rightThumbLastOffset == width {
+            self.bringSubviewToFront(self.minThumbView)
+        }
     }
     
     public func moveRightThumb(at ratio: CGFloat, barWidth: CGFloat? = nil) {
@@ -77,6 +82,11 @@ public final class DealiSliderBar: UIControl {
             $0.centerX.equalTo(self.barView.snp.left).offset(rightThumbLastOffset)
             $0.top.bottom.equalToSuperview()
             $0.size.equalTo(CGSize(width: 22.0, height: 22.0))
+        }
+        
+        // 최솟값과 동일
+        if ratio == 0 && self.leftThumbLastOffset == 0.0 {
+            self.bringSubviewToFront(self.maxThumbView)
         }
     }
     

--- a/Sources/DealiDesignKit/Components/SliderBar/DealiSliderBar.swift
+++ b/Sources/DealiDesignKit/Components/SliderBar/DealiSliderBar.swift
@@ -60,10 +60,7 @@ public final class DealiSliderBar: UIControl {
             $0.centerX.equalTo(self.barView.snp.left).offset(leftThumbLastOffset)
         }
         
-        // 최댓값과 동일
-        if ratio == 1 && self.rightThumbLastOffset == width {
-            self.bringSubviewToFront(self.minThumbView)
-        }
+        self.setThumbViewDisplayPriority(width: width)
     }
     
     public func moveRightThumb(at ratio: CGFloat, barWidth: CGFloat? = nil) {
@@ -84,9 +81,16 @@ public final class DealiSliderBar: UIControl {
             $0.size.equalTo(CGSize(width: 22.0, height: 22.0))
         }
         
-        // 최솟값과 동일
-        if ratio == 0 && self.leftThumbLastOffset == 0.0 {
-            self.bringSubviewToFront(self.maxThumbView)
+        self.setThumbViewDisplayPriority(width: width)
+    }
+    
+    private func setThumbViewDisplayPriority(width: CGFloat) {
+        if self.leftThumbLastOffset == self.rightThumbLastOffset {
+            if self.leftThumbLastOffset == width {
+                self.bringSubviewToFront(self.minThumbView)
+            } else if self.leftThumbLastOffset == 0 {
+                self.bringSubviewToFront(self.maxThumbView)
+            }
         }
     }
     


### PR DESCRIPTION
## PR 마감기한
24.05.23

## 이슈
max와 min값이 같고, 둘다 최 우측인 max값에 위치해있을때 Right Thumb가 위로 올라와있어 최솟값 수정이 불가한 현상 발생

## 수정내용
- max와 min 값이 같고, 최소 또는 최대값에 위치하는 경우 Thumb의 노출 우선순위를 지정해주었습니다. 
- SearchInput 디자인시스템 수정사항 반영
![image](https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/66dbd5d2-a90a-44c5-af52-27fa17524f40)

