### PR TITLE
TabBar isStandAloneView를 setTabBar 매개변수로 추가

### DIFF
--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -199,7 +199,7 @@ final public class DealiTabBarView: UIView {
     }
     
     /// TabBar를 구성할 정보를 받아 TabBar Item Button 생성 및 정보 저장
-    public func setTabBarItems(tabBarItemArray: [DealiTabBarItem], maintainContentOffset: Bool = true, startIndex: Int = 0) {
+    public func setTabBarItems(tabBarItemArray: [DealiTabBarItem], maintainContentOffset: Bool = true, startIndex: Int = 0, isStandAloneView: Bool = false) {
         
         /// 가려지는 tabbar item이 있다면 해당 아이템을 제외하고 TabBarView를 재구성
         let itemArray = tabBarItemArray.filter({ $0.isHidden == false })
@@ -207,7 +207,7 @@ final public class DealiTabBarView: UIView {
         let offset = self.contentScrollView.contentOffset
         
         self.clear()
-        
+        self.isStandAloneView = isStandAloneView
         for (index, item) in itemArray.enumerated() {
             guard let title = item.title else { continue }
             var buttonContentWidth = title.size(withAttributes: [.font: self.preset.selectedFont]).width


### PR DESCRIPTION
### 발생 이슈
디자인시스템에서 탭바 진입 시 스크롤 해주는 기능 (setSelectedIndexWithScroll) 의 조건에 
isStandAloneView 플래그가 있습니다.  (탭바 단독 사용 여부)

### 원인
default 값 변경되면서 기존 가테고리 탭바에서 **setTabBarItems 호출이 isStandAloneView 세팅보다 빠르면**
디자인시스템에서 isStandAloneView 값이 반영되지 않아 스크롤처리가 되지 않습니다. 

### 해결방안
디자인시스템 setTabBarItems 에서 매개변수로 해당 값을 다룰 수 있도록 수정하였습니다.
금일 함께 병합 및 검수제출 희망합니다.

### 영향범위
소매 카테고리 상품 리스트 진입
- 여성의류 - 비치웨어 등 상품리스트 탭바가 스크롤이 필요한 케이스
