### PR TITLE
[MP-4802] SemiMedium 타입 버튼 추가

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/ButtonViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/ButtonViewController.swift
@@ -131,6 +131,33 @@ class ButtonViewController: UIViewController {
                                            DealiControl.btnTextMedium07()
                                              ]
         
+        let semiMediumButtonArray: [UIView] = [DealiControl.btnFilledSemiMedium01(),
+                                               DealiControl.btnFilledSemiMedium02(),
+                                               DealiControl.btnFilledSemiMedium03(),
+                                               DealiControl.btnFilledTonalSemiMedium01(),
+                                               DealiControl.btnFilledTonalSemiMedium02(),
+                                               DealiControl.btnFilledTonalSemiMedium03(),
+                                               DealiControl.btnFilledTonalSemiMedium04(),
+                                               DealiControl.btnFilledTonalSemiMedium05(),
+                                               DealiControl.btnOutlineSemiMedium01(),
+                                               DealiControl.btnOutlineSemiMedium02(),
+                                               DealiControl.btnOutlineSemiMedium03(),
+                                               DealiControl.btnOutlineSemiMedium04(),
+                                               DealiControl.btnOutlineSemiMedium05(),
+                                               DealiControl.btnOutlineSemiMedium06(),
+                                               DealiControl.btnOutlineBgSemiMedium01(),
+                                               DealiControl.btnOutlineBgSemiMedium03(),
+                                               DealiControl.btnOutlineBgSemiMedium04(),
+                                               DealiControl.btnOutlineBgSemiMedium05(),
+                                               DealiControl.btnTextSemiMedium01(),
+                                               DealiControl.btnTextSemiMedium02(),
+                                               DealiControl.btnTextSemiMedium03(),
+                                               DealiControl.btnTextSemiMedium04(),
+                                               DealiControl.btnTextSemiMedium05(),
+                                               DealiControl.btnTextSemiMedium06(),
+                                               DealiControl.btnTextSemiMedium07()
+                                           ]
+        
         let smallButtonArray: [UIView] = [DealiControl.btnFilledSmall01(),
                                           DealiControl.btnFilledSmall03(),
                                           DealiControl.btnFilledTonalSmall01(),
@@ -165,6 +192,7 @@ class ButtonViewController: UIViewController {
         
         buttonArray += largeButtonArray
         buttonArray += mediumButtonArray
+        buttonArray += semiMediumButtonArray
         buttonArray += smallButtonArray
         
         

--- a/Sources/DealiDesignKit/Components/Alert/DealiAlert.swift
+++ b/Sources/DealiDesignKit/Components/Alert/DealiAlert.swift
@@ -44,7 +44,7 @@ public class DealiAlert: NSObject {
         checkBoxContainerView.addSubview(checkBoxView)
         checkBoxView.then {
             $0.text = checkButtonTitle
-            $0.font = .b1sb15
+            $0.font = .b2r14
             $0.status = .init()
         }.snp.makeConstraints {
             $0.top.equalToSuperview().offset(10.0)

--- a/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
+++ b/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
@@ -510,6 +510,8 @@ extension ClickableComponent {
                 return 16.0
             case .medium:
                 return 12.0
+            case .semiMedium:
+                return 12.0
             case .small:
                 return 8.0
             case .none:
@@ -539,6 +541,7 @@ extension ClickableComponent {
         public enum Height {
             case small
             case medium
+            case semiMedium
             case large
             
             var button: CGFloat {
@@ -547,6 +550,8 @@ extension ClickableComponent {
                     return 50.0
                 case .medium:
                     return 46.0
+                case .semiMedium:
+                    return 40.0
                 default:
                     return 32.0
                 }
@@ -575,6 +580,8 @@ extension ClickableComponent {
                     return self.largePadding(with: style)
                 case .medium:
                     return self.mediumPadding(with: style)
+                case .semiMedium:
+                    return self.semiMediumPadding(with: style)
                 case .small:
                     return self.smallPadding(with: style)
                 }
@@ -609,6 +616,21 @@ extension ClickableComponent {
                         return ClickablePadding(left: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0),
                                                 right: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0))
                     }
+                case .raund:
+                    return ClickablePadding(left: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0),
+                                            right: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0))
+                case .text:
+                    return ClickablePadding(left: ClickablePaddingSet(normal: 16.0, withImage: 16.0, internalSpacing: 4.0),
+                                            right: ClickablePaddingSet(normal: 16.0, withImage: 16.0, internalSpacing: 4.0))
+                }
+            }
+            
+            private func semiMediumPadding(with style: ClickableComponent.Configuration.Style) -> ClickablePadding {
+                switch self {
+                case .square:
+                    return ClickablePadding(left: ClickablePaddingSet(normal: 20.0, withImage: 16.0, internalSpacing: 4.0),
+                                            right: ClickablePaddingSet(normal: 20.0, withImage: 16.0, internalSpacing: 4.0))
+                    
                 case .raund:
                     return ClickablePadding(left: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0),
                                             right: ClickablePaddingSet(normal: 16.0, withImage: 12.0, internalSpacing: 4.0))

--- a/Sources/DealiDesignKit/Components/Control/Buttons/FilledButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/FilledButton.swift
@@ -24,7 +24,7 @@ extension DealiControl {
                                         color: ButtonFilledColor.primary02)
     }
 
-    // MARK: Medium
+    // MARK: - Medium
     public static func btnFilledMedium01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonFilledConfig.medium,
                                         color: ButtonFilledColor.primary01)
@@ -40,7 +40,24 @@ extension DealiControl {
                                         color: ButtonFilledColor.primary02)
     }
     
-    // MARK: Small
+    // MARK: - Semi Medium
+    public static func btnFilledSemiMedium01() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledConfig.semiMedium,
+                                        color: ButtonFilledColor.primary01)
+    }
+    
+    public static func btnFilledSemiMedium02() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledConfig.semiMedium,
+                                        color: ButtonFilledColor.gradient)
+    }
+    
+    public static func btnFilledSemiMedium03() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledConfig.semiMedium,
+                                        color: ButtonFilledColor.primary02)
+    }
+    
+    
+    // MARK: - Small
     public static func btnFilledSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonFilledConfig.small,
                                         color: ButtonFilledColor.primary01)
@@ -57,6 +74,7 @@ extension DealiControl {
     }
 }
 
+// MARK: - ButtonFilledColor
 public enum ButtonFilledColor: ClickableColorConfig {
     case primary01
     case primary02
@@ -77,9 +95,11 @@ public enum ButtonFilledColor: ClickableColorConfig {
     }
 }
 
+// MARK: - ButtonFilledConfig
 public enum ButtonFilledConfig: ClickableConfig {
     case large
     case medium
+    case semiMedium
     case small
     
     public var font: ClickableFont {
@@ -87,6 +107,8 @@ public enum ButtonFilledConfig: ClickableConfig {
         case .large:
             return ClickableFont.button(font: .b1sb15)
         case .medium:
+            return ClickableFont.button(font: .b2sb14)
+        case .semiMedium:
             return ClickableFont.button(font: .b2sb14)
         case .small:
             return ClickableFont.button(font: .b3sb13)
@@ -99,6 +121,8 @@ public enum ButtonFilledConfig: ClickableConfig {
             return .large
         case .medium:
             return .medium
+        case .semiMedium:
+            return .semiMedium
         case .small:
             return .small
         }
@@ -109,6 +133,8 @@ public enum ButtonFilledConfig: ClickableConfig {
         case .large:
             return .fixed(6.0)
         case .medium:
+            return .fixed(6.0)
+        case .semiMedium:
             return .fixed(6.0)
         case .small:
             return .fixed(4.0)

--- a/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
@@ -39,7 +39,7 @@ extension DealiControl {
                                         color: ButtonFilledTonalColor.secondary04)
     }
     
-    // MARK: Medium
+    // MARK: - Medium
     public static func btnFilledTonalMedium01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonFilledTonalConfig.medium,
                                         color: ButtonFilledTonalColor.primary01)
@@ -65,7 +65,33 @@ extension DealiControl {
                                         color: ButtonFilledTonalColor.secondary03)
     }
     
-    // MARK: Small
+    // MARK: - Semi Medium
+    public static func btnFilledTonalSemiMedium01() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.primary01)
+    }
+    
+    public static func btnFilledTonalSemiMedium02() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.primary02)
+    }
+    
+    public static func btnFilledTonalSemiMedium03() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.secondary01)
+    }
+    
+    public static func btnFilledTonalSemiMedium04() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.secondary02)
+    }
+   
+    public static func btnFilledTonalSemiMedium05() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.secondary03)
+    }
+    
+    // MARK: - Small
     public static func btnFilledTonalSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonFilledTonalConfig.small,
                                         color: ButtonFilledTonalColor.primary01)
@@ -153,6 +179,7 @@ public enum ButtonFilledTonalColor: ClickableColorConfig {
 public enum ButtonFilledTonalConfig: ClickableConfig {
     case large
     case medium
+    case semiMedium
     case small
     case roundSmall
     
@@ -161,6 +188,8 @@ public enum ButtonFilledTonalConfig: ClickableConfig {
         case .large:
             return ClickableFont.button(font: .b1sb15)
         case .medium:
+            return ClickableFont.button(font: .b2sb14)
+        case .semiMedium:
             return ClickableFont.button(font: .b2sb14)
         case .small:
             return ClickableFont.button(font: .b3sb13)
@@ -175,6 +204,8 @@ public enum ButtonFilledTonalConfig: ClickableConfig {
             return .large
         case .medium:
             return .medium
+        case .semiMedium:
+            return .semiMedium
         case .small:
             return .small
         case .roundSmall:
@@ -188,6 +219,8 @@ public enum ButtonFilledTonalConfig: ClickableConfig {
             return .fixed(6.0)
         case .medium:
             return .fixed(6.0)
+        case .semiMedium:
+            return .fixed(6.0)
         case .small:
             return .fixed(4.0)
         case .roundSmall:
@@ -200,6 +233,8 @@ public enum ButtonFilledTonalConfig: ClickableConfig {
         case .large:
             return .square
         case .medium:
+            return .square
+        case .semiMedium:
             return .square
         case .small:
             return .square

--- a/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
@@ -144,6 +144,7 @@ extension DealiControl {
     
 }
 
+// MARK: - ClickableColorConfig
 public enum ButtonFilledTonalColor: ClickableColorConfig {
     case primary01
     case primary02
@@ -176,6 +177,7 @@ public enum ButtonFilledTonalColor: ClickableColorConfig {
     }
 }
 
+// MARK: - ClickableConfig
 public enum ButtonFilledTonalConfig: ClickableConfig {
     case large
     case medium

--- a/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/FilledTonalButton.swift
@@ -91,6 +91,11 @@ extension DealiControl {
                                         color: ButtonFilledTonalColor.secondary03)
     }
     
+    public static func btnFilledTonalSemiMedium06() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonFilledTonalConfig.semiMedium,
+                                        color: ButtonFilledTonalColor.secondary04)
+    }
+    
     // MARK: - Small
     public static func btnFilledTonalSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonFilledTonalConfig.small,

--- a/Sources/DealiDesignKit/Components/Control/Buttons/OutlineBgButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/OutlineBgButton.swift
@@ -112,7 +112,7 @@ extension DealiControl {
                                         color: ButtonBgOutlineColor.secondary04)
     }
 }
-
+// MARK: - ClickableColorConfig
 public enum ButtonBgOutlineColor: ClickableColorConfig {
     case primary01
     case secondary01
@@ -140,7 +140,7 @@ public enum ButtonBgOutlineColor: ClickableColorConfig {
         }
     }
 }
-
+// MARK: - ClickableConfig
 public enum ButtonBgOutlineConfig: ClickableConfig {
     case large
     case medium

--- a/Sources/DealiDesignKit/Components/Control/Buttons/OutlineBgButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/OutlineBgButton.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension DealiControl {
-    
+    // MARK: Large
     public static func btnOutlineBgLarge01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonBgOutlineConfig.large,
                                         color: ButtonBgOutlineColor.primary01)
@@ -34,6 +34,7 @@ extension DealiControl {
                                         color: ButtonBgOutlineColor.secondary04)
     }
     
+    // MARK: - Medium
     public static func btnOutlineBgMedium01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonBgOutlineConfig.medium,
                                         color: ButtonBgOutlineColor.primary01)
@@ -59,6 +60,33 @@ extension DealiControl {
                                         color: ButtonBgOutlineColor.secondary04)
     }
     
+    // MARK: - Semi Medium
+    public static func btnOutlineBgSemiMedium01() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonBgOutlineConfig.semiMedium,
+                                        color: ButtonBgOutlineColor.primary01)
+    }
+
+    public static func btnOutlineBgSemiMedium03() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonBgOutlineConfig.semiMedium,
+                                        color: ButtonBgOutlineColor.secondary01)
+    }
+    
+    public static func btnOutlineBgSemiMedium04() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonBgOutlineConfig.semiMedium,
+                                        color: ButtonBgOutlineColor.secondary02)
+    }
+    
+    public static func btnOutlineBgSemiMedium05() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonBgOutlineConfig.semiMedium,
+                                        color: ButtonBgOutlineColor.secondary03)
+    }
+    
+    public static func btnOutlineBgSemiMedium06() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonBgOutlineConfig.semiMedium,
+                                        color: ButtonBgOutlineColor.secondary04)
+    }
+    
+    // MARK: - Small
     public static func btnOutlineBgSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonBgOutlineConfig.small,
                                         color: ButtonBgOutlineColor.primary01)
@@ -116,6 +144,7 @@ public enum ButtonBgOutlineColor: ClickableColorConfig {
 public enum ButtonBgOutlineConfig: ClickableConfig {
     case large
     case medium
+    case semiMedium
     case small
     
     public var font: ClickableFont {
@@ -123,6 +152,8 @@ public enum ButtonBgOutlineConfig: ClickableConfig {
         case .large:
             return ClickableFont.button(font: .b1sb15)
         case .medium:
+            return ClickableFont.button(font: .b2sb14)
+        case .semiMedium:
             return ClickableFont.button(font: .b2sb14)
         case .small:
             return ClickableFont.button(font: .b3sb13)
@@ -135,6 +166,8 @@ public enum ButtonBgOutlineConfig: ClickableConfig {
             return .large
         case .medium:
             return .medium
+        case .semiMedium:
+            return .semiMedium
         case .small:
             return .small
         }
@@ -146,6 +179,8 @@ public enum ButtonBgOutlineConfig: ClickableConfig {
             return .fixed(6.0)
         case .medium:
             return .fixed(6.0)
+        case .semiMedium:
+            return .fixed(6.0)
         case .small:
             return .fixed(4.0)
         }
@@ -156,6 +191,8 @@ public enum ButtonBgOutlineConfig: ClickableConfig {
         case .large:
             return .square
         case .medium:
+            return .square
+        case .semiMedium:
             return .square
         case .small:
             return .square

--- a/Sources/DealiDesignKit/Components/Control/Buttons/OutlineButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/OutlineButton.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 extension DealiControl {
+    // MARK: Large
     public static func btnOutlineLarge01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonOutlineConfig.large,
                                         color: ButtonOutlineColor.primary01)
@@ -38,6 +39,7 @@ extension DealiControl {
                                         color: ButtonOutlineColor.secondary04)
     }
     
+    // MARK: - Medium
     public static func btnOutlineMedium01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonOutlineConfig.medium,
                                         color: ButtonOutlineColor.primary01)
@@ -68,6 +70,38 @@ extension DealiControl {
                                         color: ButtonOutlineColor.secondary04)
     }
     
+    // MARK: - Semi Medium
+    public static func btnOutlineSemiMedium01() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.primary01)
+    }
+    
+    public static func btnOutlineSemiMedium02() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.primary02)
+    }
+    
+    public static func btnOutlineSemiMedium03() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.secondary01)
+    }
+    
+    public static func btnOutlineSemiMedium04() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.secondary02)
+    }
+    
+    public static func btnOutlineSemiMedium05() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.secondary03)
+    }
+    
+    public static func btnOutlineSemiMedium06() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonOutlineConfig.semiMedium,
+                                        color: ButtonOutlineColor.secondary04)
+    }
+    
+    // MARK: - Small
     public static func btnOutlineSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonOutlineConfig.small,
                                         color: ButtonOutlineColor.primary01)
@@ -164,6 +198,7 @@ public enum ButtonOutlineColor: ClickableColorConfig {
 public enum ButtonOutlineConfig: ClickableConfig {
     case large
     case medium
+    case semiMedium
     case small
     case roundSmall
     
@@ -172,6 +207,8 @@ public enum ButtonOutlineConfig: ClickableConfig {
         case .large:
             return ClickableFont.button(font: .b1sb15)
         case .medium:
+            return ClickableFont.button(font: .b2sb14)
+        case .semiMedium:
             return ClickableFont.button(font: .b2sb14)
         case .small:
             return ClickableFont.button(font: .b3sb13)
@@ -186,6 +223,8 @@ public enum ButtonOutlineConfig: ClickableConfig {
             return .large
         case .medium:
             return .medium
+        case .semiMedium:
+            return .medium
         case .small:
             return .small
         case .roundSmall:
@@ -199,6 +238,8 @@ public enum ButtonOutlineConfig: ClickableConfig {
             return .fixed(6.0)
         case .medium:
             return .fixed(6.0)
+        case .semiMedium:
+            return .fixed(6.0)
         case .small:
             return .fixed(4.0)
         case .roundSmall:
@@ -211,6 +252,8 @@ public enum ButtonOutlineConfig: ClickableConfig {
         case .large:
             return .square
         case .medium:
+            return .square
+        case .semiMedium:
             return .square
         case .small:
             return .square

--- a/Sources/DealiDesignKit/Components/Control/Buttons/OutlineButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/OutlineButton.swift
@@ -163,6 +163,7 @@ extension DealiControl {
     }
 }
 
+// MARK: - ClickableColorConfig
 public enum ButtonOutlineColor: ClickableColorConfig {
     case primary01
     case primary02
@@ -195,6 +196,7 @@ public enum ButtonOutlineColor: ClickableColorConfig {
     }
 }
 
+// MARK: - ClickableConfig
 public enum ButtonOutlineConfig: ClickableConfig {
     case large
     case medium

--- a/Sources/DealiDesignKit/Components/Control/Buttons/TextButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/TextButton.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 extension DealiControl {
+    // MARK: Large
     public static func btnTextLarge01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonTextConfig.large,
                                         color: ButtonTextColor.primary01)
@@ -43,6 +44,7 @@ extension DealiControl {
                                         color: ButtonTextColor.secondary05)
     }
     
+    // MARK: - Medium
     public static func btnTextMedium01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonTextConfig.medium,
                                         color: ButtonTextColor.primary01)
@@ -78,6 +80,43 @@ extension DealiControl {
                                         color: ButtonTextColor.secondary05)
     }
     
+    // MARK: - Semi Medium
+    public static func btnTextSemiMedium01() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.primary01)
+    }
+    
+    public static func btnTextSemiMedium02() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.primary02)
+    }
+    
+    public static func btnTextSemiMedium03() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.secondary01)
+    }
+    
+    public static func btnTextSemiMedium04() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.secondary02)
+    }
+    
+    public static func btnTextSemiMedium05() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.secondary03)
+    }
+    
+    public static func btnTextSemiMedium06() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.secondary04)
+    }
+    
+    public static func btnTextSemiMedium07() -> ClickableComponentButton {
+        return ClickableComponentButton(config: ButtonTextConfig.semiMedium,
+                                        color: ButtonTextColor.secondary05)
+    }
+    
+    // MARK: - Small
     public static func btnTextSmall01() -> ClickableComponentButton {
         return ClickableComponentButton(config: ButtonTextConfig.small,
                                         color: ButtonTextColor.primary01)
@@ -154,6 +193,7 @@ public enum ButtonTextColor: ClickableColorConfig {
 public enum ButtonTextConfig: ClickableConfig {
     case large
     case medium
+    case semiMedium
     case small
     
     public var font: ClickableFont {
@@ -161,6 +201,8 @@ public enum ButtonTextConfig: ClickableConfig {
         case .large:
             return ClickableFont.button(font: .b1sb15)
         case .medium:
+            return ClickableFont.button(font: .b2r14)
+        case .semiMedium:
             return ClickableFont.button(font: .b2r14)
         case .small:
             return ClickableFont.button(font: .b3r13)
@@ -173,6 +215,8 @@ public enum ButtonTextConfig: ClickableConfig {
             return .large
         case .medium:
             return .medium
+        case .semiMedium:
+            return .medium
         case .small:
             return .small
         }
@@ -183,6 +227,8 @@ public enum ButtonTextConfig: ClickableConfig {
         case .large:
             return .fixed(6.0)
         case .medium:
+            return .fixed(6.0)
+        case .semiMedium:
             return .fixed(6.0)
         case .small:
             return .fixed(4.0)

--- a/Sources/DealiDesignKit/Components/Control/Buttons/TextButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/Buttons/TextButton.swift
@@ -153,7 +153,7 @@ extension DealiControl {
     }
     
 }
-
+// MARK: - ClickableColorConfig
 public enum ButtonTextColor: ClickableColorConfig {
     case primary01
     case primary02
@@ -189,7 +189,7 @@ public enum ButtonTextColor: ClickableColorConfig {
         }
     }
 }
-
+// MARK: - ClickableConfig
 public enum ButtonTextConfig: ClickableConfig {
     case large
     case medium

--- a/Sources/DealiDesignKit/Components/Control/ClickableComponent.swift
+++ b/Sources/DealiDesignKit/Components/Control/ClickableComponent.swift
@@ -645,7 +645,7 @@ extension ChipComponent {
                 switch height {
                 case .large:
                     return self.largePadding(with: style)
-                case .medium:
+                case .medium, .semiMedium:
                     return self.mediumPadding(with: style)
                 case .small:
                     return self.smallPadding(with: style)


### PR DESCRIPTION
- SemiMedium 타입 버튼 추가 (칩은 해당 타입 없습니다)
제니 소매 글로벌 주문목록 > 주문 취소 버튼에 사용
기존 Medium과 높이만 다르고 다른 값들은 동일합니다. 
![IMG_0134](https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/60bc7ce4-f70b-4174-9c2a-aa419d41a67c)

- DealiAlert 체크박스 타이틀 문구 폰트 수정 (b1sb15 -> b2r14)
![IMG_0135](https://github.com/dealicious-inc/ssm-mobile-ios-design-system/assets/148742598/4801a02d-e6cf-4f13-b56f-26942f2673b3)
