### PR TITLE
ClickableImage 에 dealiIcon name을 바로 사용할 수 있는 코드 추가

### DIFF
--- a/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
+++ b/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
@@ -741,6 +741,11 @@ public struct ClickableImage {
         self.needOriginColor = needOriginColor
         self.uiImage = UIImage(named: name)
     }
+    public init(dealiIconName: String, needOriginColor: Bool = false) {
+        self.named = dealiIconName
+        self.needOriginColor = needOriginColor
+        self.uiImage = UIImage.dealiIcon(named: dealiIconName)
+    }
     public init(_ image: UIImage?, needOriginColor: Bool = false) {
         self.named = ""
         self.uiImage = image


### PR DESCRIPTION
## 작업 내용
- ClickableImage에서 dealiIcon을 사용할려면 
ClickableImage(UIImage.dealiIcon(named: "이미지명")) 이렇게 사용해야 했는데
ClickableImage(dealiIconName: "이미지명") 으로도 사용할 수 있게 코드 추가

