### PR TITLE
[MP-5335] 2버튼 바텀시트 취소버튼 다른 타입

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
@@ -58,6 +58,15 @@ final class BottomSheetPopupTestViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
+        let bottomSheetPopupButton011 = DealiControl.btnOutlineLarge01()
+        contentStackView.addArrangedSubview(bottomSheetPopupButton011)
+        bottomSheetPopupButton011.then {
+            $0.title = "2버튼 팝업 (취소버튼 btnOutlineLarge06)"
+            $0.addTarget(self, action: #selector(bottomSheetPopupButton011Pressed), for: .touchUpInside)
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+        
         let singleSelectBottomSheetButton = DealiControl.btnOutlineLarge01()
         contentStackView.addArrangedSubview(singleSelectBottomSheetButton)
         singleSelectBottomSheetButton.then {
@@ -114,6 +123,18 @@ extension BottomSheetPopupTestViewController {
             titleType: .titleCloseButton(title: "2버튼 팝업"),
             message: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
             buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소"),
+            popupPresentingViewController: self,
+            cancelAction: nil, confirmAction: nil
+        )
+    }
+    
+    @objc func bottomSheetPopupButton011Pressed() {
+        debugPrint("bottomSheetPopupButton01Pressed")
+
+        DealiBottomSheet.showTextOnly(
+            titleType: .titleCloseButton(title: "2버튼 팝업"),
+            message: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
+            buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소", cancelButtonType: .btnOutlineLarge06),
             popupPresentingViewController: self,
             cancelAction: nil, confirmAction: nil
         )

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -45,7 +45,12 @@ public enum EBottomSheetTitleType: Equatable {
 public enum EBottomSheetButtonType: Equatable {
     case hidden
     case oneButton(buttonTitle: String?)
-    case twoButton(confirmTitle: String?, cancelTitle: String?)
+    case twoButton(confirmTitle: String?, cancelTitle: String?, cancelButtonType: EBottomSheetCancelButtonType? = .btnOutlineLarge01)
+}
+
+public enum EBottomSheetCancelButtonType {
+    case btnOutlineLarge01
+    case btnOutlineLarge06
 }
 
 public class DealiBottomSheet: NSObject {
@@ -280,11 +285,7 @@ class DealiBottomSheetSystemViewController: UIViewController {
         }
     }()
     
-    private lazy var cancelButton: ClickableComponentButton = {
-        return DealiControl.btnOutlineLarge01().then {
-            $0.addTarget(self, action: #selector(cancelButtonAction), for: .touchUpInside)
-        }
-    }()
+    private lazy var cancelButton: ClickableComponentButton = DealiControl.btnOutlineLarge01()
     
     private lazy var confirmButton: ClickableComponentButton = {
         return DealiControl.btnFilledLarge01().then {
@@ -481,7 +482,9 @@ class DealiBottomSheetSystemViewController: UIViewController {
             self.confirmButton.snp.makeConstraints {
                 $0.top.bottom.equalToSuperview()
             }
-        case .twoButton(let confirmTitle, let cancelTitle):
+        case .twoButton(let confirmTitle, let cancelTitle, let cancelButtonType):
+            self.cancelButton = cancelButtonType == .btnOutlineLarge01 ? DealiControl.btnOutlineLarge01() : DealiControl.btnOutlineLarge06()
+            self.cancelButton.addTarget(self, action: #selector(cancelButtonAction), for: .touchUpInside)
             buttonStackView.addArrangedSubview(self.cancelButton)
             self.cancelButton.title = cancelTitle
             self.cancelButton.snp.makeConstraints {


### PR DESCRIPTION
## PR 마감기한
2025.01.17(금요일)

## 작업 내용
- 다른 취소버튼을 가지는 2버튼 바텀시트 구현

## 주의해서 봐야 할 부분
```Swift
DealiBottomSheet.showTextOnly(
    titleType: .titleCloseButton(title: "2버튼 팝업"),
    message: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오",
    buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소", cancelButtonType: .btnOutlineLarge06), // <- 취소버튼 타입 지정
    popupPresentingViewController: self,
    cancelAction: nil, confirmAction: nil
)
```

<img src="https://github.com/user-attachments/assets/02cf3ad4-f549-4b7c-8a50-8fe4a629b386" width="450">
