### PR TITLE
[MP-5418] 바텀시트 내 텍스트필드 있을 때 키보드에 따라 레이아웃 조정되도록 변경

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		4D58315E2B033EC4009F7B48 /* SliderBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D58315D2B033EC4009F7B48 /* SliderBarViewController.swift */; };
 		4D584A1E2D1A82BF007BB775 /* NoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D584A1D2D1A82BF007BB775 /* NoticeViewController.swift */; };
 		4D584A202D22758B007BB775 /* GradientColorItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D584A1F2D22758B007BB775 /* GradientColorItemView.swift */; };
-		4D96495B2BDA227D00AC1BDE /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 4D96495A2BDA227D00AC1BDE /* RxKeyboard */; };
 		4DB2D6F42AFB281100DFF053 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2D6F32AFB281100DFF053 /* BottomSheetViewController.swift */; };
 		4DE326202CDB61CF00E67FEC /* ImageChipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE3261F2CDB61CF00E67FEC /* ImageChipViewController.swift */; };
 		4DF5ABEB2CC25E1300BFB7D6 /* ColorItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF5ABEA2CC25E1300BFB7D6 /* ColorItemView.swift */; };
@@ -117,7 +116,6 @@
 				041ABC062A174598001772F3 /* RxRelay in Frameworks */,
 				041ABC042A174598001772F3 /* RxCocoa in Frameworks */,
 				041ABC082A174598001772F3 /* RxSwift in Frameworks */,
-				4D96495B2BDA227D00AC1BDE /* RxKeyboard in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -317,7 +315,6 @@
 				041ABC052A174598001772F3 /* RxRelay */,
 				041ABC072A174598001772F3 /* RxSwift */,
 				E6D2214A2AAEE733000A6411 /* DealiDesignKit */,
-				4D96495A2BDA227D00AC1BDE /* RxKeyboard */,
 				FC5D88292D2BB52C008F7133 /* DealiDesignKit */,
 			);
 			productName = DealiDesignSystemSampleApp;
@@ -351,7 +348,6 @@
 			mainGroup = 042EA89C2A14C7D500370706;
 			packageReferences = (
 				041ABC022A174598001772F3 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				4D9649592BDA227D00AC1BDE /* XCRemoteSwiftPackageReference "RxKeyboard" */,
 			);
 			productRefGroup = 042EA8A62A14C7D500370706 /* Products */;
 			projectDirPath = "";
@@ -642,14 +638,6 @@
 				version = 6.8.0;
 			};
 		};
-		4D9649592BDA227D00AC1BDE /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/RxSwiftCommunity/RxKeyboard.git";
-			requirement = {
-				kind = exactVersion;
-				version = 2.0.1;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -667,11 +655,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 041ABC022A174598001772F3 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
-		};
-		4D96495A2BDA227D00AC1BDE /* RxKeyboard */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4D9649592BDA227D00AC1BDE /* XCRemoteSwiftPackageReference "RxKeyboard" */;
-			productName = RxKeyboard;
 		};
 		E6D2214A2AAEE733000A6411 /* DealiDesignKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "rxkeyboard",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RxSwiftCommunity/RxKeyboard.git",
-      "state" : {
-        "revision" : "63f6377975c962a1d89f012a6f1e5bebb2c502b7",
-        "version" : "2.0.1"
-      }
-    },
-    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
@@ -248,6 +248,15 @@ extension BottomSheetPopupTestViewController {
             $0.backgroundColor = .g05
         }
         
+        let textInput = DealiTextInput_v2()
+        customView.addSubview(textInput)
+        textInput.then {
+            $0.placeholder = "텍스트필드"
+        }.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20.0)
+            $0.left.right.equalToSuperview().inset(20.0)
+        }
+
         let colorImageView = UIImageView()
         customView.addSubview(colorImageView)
         colorImageView.then {
@@ -255,7 +264,8 @@ extension BottomSheetPopupTestViewController {
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 50.0
         }.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.top.equalTo(textInput.snp.bottom).offset(20.0)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(CGSize(width: 100.0, height: 100.0))
         }

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import DealiDesignKit
 import RxSwift
-import RxKeyboard
 import OSLog
 import Then
 
@@ -22,16 +21,6 @@ final class DealiPlaygroundViewController: UIViewController {
         super.viewDidLoad()
         
         self.title = "Playground"
-        
-        RxKeyboard.instance.visibleHeight
-            .drive(onNext: { [weak self] keyboardHeight in
-                guard let self else { return }
-                let bottomMargin = keyboardHeight > 0 ? keyboardHeight + 20.0 : 0
-                self.scrollView.snp.updateConstraints {
-                    $0.bottom.equalToSuperview().inset(bottomMargin)
-                }
-            })
-            .disposed(by: self.disposeBag)
     }
     
     override func loadView() {
@@ -65,7 +54,43 @@ final class DealiPlaygroundViewController: UIViewController {
         let textInputView = TextInputValidationView()
         contentStackView.addArrangedSubview(textInputView)
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardShowNotification(_:)), name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardHideNotification(_:)), name: UIWindow.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardShowNotification(_ notification: NSNotification) {
 
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardVisibleHeight = keyboardFrame.cgRectValue.height
+        let bottomMargin = keyboardVisibleHeight > 0 ? keyboardVisibleHeight + 20.0 : 0
+        self.scrollView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(bottomMargin)
+        }
+        self.view.layoutIfNeeded()
+    }
+    
+    @objc func keyboardHideNotification(_ notification: NSNotification) {
+
+        guard let _ = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        
+        self.scrollView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(0.0)
+        }
+        self.view.layoutIfNeeded()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillHideNotification, object: nil)
+    }
 }
 
 final class TextInputValidationView: UIView {

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextAreaViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextAreaViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import DealiDesignKit
 import RxSwift
 import RxCocoa
-import RxKeyboard
 
 final class TextAreaViewController: UIViewController {
     
@@ -45,18 +44,48 @@ final class TextAreaViewController: UIViewController {
                 debugPrint("rightButton 눌림")
             }
             .disposed(by: self.disposeBag)
-        
-        RxKeyboard.instance.visibleHeight
-            .drive(onNext: { [weak self] keyboardHeight in
-                guard let self else { return }
-                let bottomMargin = keyboardHeight > 0 ? keyboardHeight + 20.0 : 0
-                self.contentScrollView.snp.updateConstraints {
-                    $0.bottom.equalToSuperview().inset(bottomMargin)
-                }
-            })
-            .disposed(by: self.disposeBag)
 
     }
+    
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardShowNotification(_:)), name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardHideNotification(_:)), name: UIWindow.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardShowNotification(_ notification: NSNotification) {
+
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardVisibleHeight = keyboardFrame.cgRectValue.height
+        let bottomMargin = keyboardVisibleHeight + 20.0
+        self.contentScrollView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(bottomMargin)
+        }
+        self.view.layoutIfNeeded()
+    }
+    
+    @objc func keyboardHideNotification(_ notification: NSNotification) {
+
+        guard let _ = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        
+        self.contentScrollView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(0.0)
+        }
+        self.view.layoutIfNeeded()
+        
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillHideNotification, object: nil)
+    }
+    
     
     override func loadView() {
         self.view = .init()

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TypographyViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TypographyViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 import DealiDesignKit
-import RxKeyboard
 
 /**
  설명: 폰트 관련

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import RxKeyboard
 import RxSwift
 
 enum EBottomSheetOptionType: Equatable {
@@ -235,7 +234,6 @@ class DealiBottomSheetSystemViewController: UIViewController {
     private let contentView = UIView()
     private var cornerLayer: CAShapeLayer?
     private let contentStackView = UIStackView()
-    private let disposeBag = DisposeBag()
     
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -312,19 +310,46 @@ class DealiBottomSheetSystemViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.setKeyboard()
     }
     
-    private func setKeyboard() {
-        RxKeyboard.instance.visibleHeight
-            .drive(with: self) { owner, keyboardVisibleHeight in
-                owner.contentView.snp.remakeConstraints {
-                    $0.left.right.equalToSuperview()
-                    $0.bottom.equalToSuperview().inset(keyboardVisibleHeight)
-                }
-                owner.view.layoutIfNeeded()    
-            }
-            .disposed(by: self.disposeBag)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardShowNotification(_:)), name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardHideNotification(_:)), name: UIWindow.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardShowNotification(_ notification: NSNotification) {
+
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardVisibleHeight = keyboardFrame.cgRectValue.height
+        
+        self.contentView.snp.remakeConstraints {
+            $0.left.right.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(keyboardVisibleHeight)
+        }
+        self.view.layoutIfNeeded()
+    }
+    
+    @objc func keyboardHideNotification(_ notification: NSNotification) {
+
+        guard let _ = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        
+        self.contentView.snp.remakeConstraints {
+            $0.left.right.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(0.0)
+        }
+        self.view.layoutIfNeeded()
+        
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIWindow.keyboardWillHideNotification, object: nil)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import RxKeyboard
+import RxSwift
 
 enum EBottomSheetOptionType: Equatable {
     case singleSelect
@@ -233,6 +235,7 @@ class DealiBottomSheetSystemViewController: UIViewController {
     private let contentView = UIView()
     private var cornerLayer: CAShapeLayer?
     private let contentStackView = UIStackView()
+    private let disposeBag = DisposeBag()
     
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -309,6 +312,19 @@ class DealiBottomSheetSystemViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.setKeyboard()
+    }
+    
+    private func setKeyboard() {
+        RxKeyboard.instance.visibleHeight
+            .drive(with: self) { owner, keyboardVisibleHeight in
+                owner.contentView.snp.remakeConstraints {
+                    $0.left.right.equalToSuperview()
+                    $0.bottom.equalToSuperview().inset(keyboardVisibleHeight)
+                }
+                owner.view.layoutIfNeeded()    
+            }
+            .disposed(by: self.disposeBag)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -507,7 +523,7 @@ class DealiBottomSheetSystemViewController: UIViewController {
         self.contentView.layoutIfNeeded()
         
         self.contentView.snp.remakeConstraints {
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(0)
             $0.left.right.equalToSuperview()
         }
         


### PR DESCRIPTION
## PR 마감기한
- 2025.01.24 (금)

## 작업 내용
- 바텀시트 내 텍스트필드 있을 때 키보드에 따라 레이아웃 조정되도록 변경

## Merge 전 필요한 작업
- N/A

## 주의해서 봐야 할 부분

