### PR TITLE
[MP-5392] DealiTextInput_v2 에러 상태가 focus 상태와 관계없이 유지되도록 변경

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
@@ -101,7 +101,7 @@ final class TextInputValidationView: UIView {
                     return current
                 }
                 invalidOption.setErrorMessage(for: current)
-                self.restrictedTextInput.inputStatus = .error(invalidOption.errorMessage)
+                self.restrictedTextInput.errorStatus = .error(invalidOption.errorMessage)
 
                 return invalidOptionArray.reduce(current) { text, option -> String in
                     text.filteredText(for: option)

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
@@ -26,12 +26,12 @@ final class TextInputViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
         
-        
         self.realTimeInput.rx.textEditingControlProperty
             .bind(with: self) { owner, text in
                 if let text = text, text.rangeOfCharacter(from: .decimalDigits) != nil {
-                    owner.realTimeInput.inputStatus = .error("숫자를 포함할 수 없습니다.")
+                    owner.realTimeInput.errorStatus = .error("숫자를 포함할 수 없습니다.")
                 } else {
+                    owner.realTimeInput.errorStatus = .none
                     owner.realTimeInput.inputStatus = self.realTimeInput.textField.isFirstResponder ? .focusIn : .focusOut
                 }
             }

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
@@ -14,6 +14,7 @@ final class TextInputViewController: UIViewController {
 
     private let contentScrollView = UIScrollView()
     private let textInput = DealiTextInput_v2.text()
+    private let realTimeInput = DealiTextInput_v2.text()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,6 +26,16 @@ final class TextInputViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
         
+        
+        self.realTimeInput.rx.textEditingControlProperty
+            .bind(with: self) { owner, text in
+                if let text = text, text.rangeOfCharacter(from: .decimalDigits) != nil {
+                    owner.realTimeInput.inputStatus = .error("숫자를 포함할 수 없습니다.")
+                } else {
+                    owner.realTimeInput.inputStatus = self.realTimeInput.textField.isFirstResponder ? .focusIn : .focusOut
+                }
+            }
+            .disposed(by: self.disposeBag)
     }
     
     var disposeBag = DisposeBag()
@@ -78,6 +89,19 @@ final class TextInputViewController: UIViewController {
             
             $0.notVerifiedBadgeText = "미인증"
             $0.verifiedBadgeText = "인증"
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+        
+        contentStackView.addArrangedSubview(realTimeInput)
+        realTimeInput.then {
+            $0.title = "실시간 검증 입력"
+            $0.placeholder = "Text Input"
+            $0.keyboardCloseButtonString = "닫기"
+            $0.inputReturnKeyType = .done
+            let button = DealiControl.btnOutlineMedium03()
+            button.title = "Default"
+            $0.actionButton = button
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
         }

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInputEnum.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInputEnum.swift
@@ -11,9 +11,13 @@ public enum ETextInputStatus: Equatable {
     case normal
     case focusIn
     case focusOut
-    case error(_ errorMessage: String?)
     case disabled
     case readOnly
+}
+
+public enum ETextInputErrorStatus: Equatable {
+    case none
+    case error(String?)
 }
 
 public enum ETextInputRightViewType: Equatable {
@@ -48,8 +52,6 @@ extension ETextInputStatus {
         switch self {
         case .focusIn:
             UIColor.g100.cgColor
-        case .error:
-            UIColor.error.cgColor
         case .readOnly:
             self.backgroundColor.cgColor
         default:
@@ -65,6 +67,25 @@ extension ETextInputStatus {
             return .g80
         default:
             return .g100
+        }
+    }
+}
+
+extension ETextInputErrorStatus {
+    var textColor: UIColor {
+        return .g100
+    }
+    
+    var backgroundColor: UIColor {
+        return .primary04
+    }
+    
+    var borderColor: CGColor {
+        switch self {
+        case .error:
+            UIColor.error.cgColor
+        default:
+            UIColor.g20.cgColor
         }
     }
 }

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
@@ -150,18 +150,31 @@ open class DealiTextInput_v2: UIView, DealiTextField {
     /// confirmed 속성 나타낼 때 사용
     public var confirmingCondition: ((String?) -> Bool)?
    
+    /// TextInput 에러 상태 세팅
+    public var errorStatus: ETextInputErrorStatus = .none {
+        didSet {
+            switch self.errorStatus {
+            case let .error(errorMessage):
+                self.setError(for: errorMessage)
+                return
+            default:
+                break
+            }
+        }
+    }
+    
     /// TextInputStatus 따라 ui처리
     public var inputStatus: ETextInputStatus = .normal {
         didSet {
+            if case .error = self.errorStatus {
+                return
+            }
+            
             self.textField.textColor = self.inputStatus.textColor
             self.textFieldContentView.layer.borderColor = self.inputStatus.borderColor
             self.textFieldContentView.backgroundColor = self.inputStatus.backgroundColor
 
             switch self.inputStatus {
-            case let .error(errorMessage):
-                self.setError(for: errorMessage)
-                return
-                
             case .focusIn:
                 self.becomeFirstResponder()
 
@@ -612,6 +625,10 @@ extension DealiTextInput_v2: DealiTextFieldConfig {
     }
     
     func setError(for errorMessage: String?) {
+        
+        self.textField.textColor = self.errorStatus.textColor
+        self.textFieldContentView.layer.borderColor = self.errorStatus.borderColor
+        self.textFieldContentView.backgroundColor = self.errorStatus.backgroundColor
         
         let style = NSMutableParagraphStyle().then {
             $0.lineHeightMultiple = 1.12


### PR DESCRIPTION
## PR 마감기한
2025.02.11(화요일)

## 작업 내용
- DealiTextInput_v2의 에러 상태가 focus 상태와 관계없이 유지되도록 변경
- DealiTextInput_v2 의 에러 상태가, focus 상태와 구별되도록 ETextInputStatus와 ETextInputErrorStatus를 분리

## Merge 전 필요한 작업
- 연관된 신상마켓 PR: https://github.com/dealicious-inc/ssm-mobile-ios/pull/1031

## 주의해서 봐야 할 부분
- DealiTextInput_v2을 사용할 때 에러 상태를 표시할 때는 아래 코드처럼 처리
```Swift
let textInput = DealiTextInput_v2()

// 에러 일 때
textInput.errorStatus = .error("에러텍스트")
// 에러가 아닐 때
textInput.errorStatus = .none

// inputStatus는 errorStatus 와 관련없이 관리
textInput.inputStatus = .focusIn
```
