### PR TITLE
[MP-5496] setLineHeight를 다중폰트의 max 값 기준으로 적용 지원되도록 개선

### DIFF
--- a/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
@@ -106,31 +106,43 @@ public extension NSMutableAttributedString {
         return self
     }
 
-    /// 폰트사이즈에 정의되어 있는 LineHeight값으로 text LineHeight 값 설정 및 baselineOffset 정의
+    /// 폰트사이즈에 정의되어 있는 LineHeight값으로 text max LineHeight 값 설정 및 baselineOffset 정의
+    /// 반드시 모든 AttString을 합친뒤 가장 마지막에만 적용합니다.
     func setLineHeight() -> NSMutableAttributedString {
         let source = self.string
-        
         guard source.isEmpty == false else { return self }
         
-        if let font: UIFont = self.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
-            let lineHeight = font.dealiLineHeight
-            let range = (source as NSString).range(of: source)
-            var style: NSMutableParagraphStyle?
-            if let paragraphStyle = self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle {
-                style = paragraphStyle
-            } else {
-                style = NSMutableParagraphStyle()
-            }
-            
-            style?.minimumLineHeight = lineHeight
-            style?.maximumLineHeight = lineHeight
-            
-            let baselineOffset = ((lineHeight - font.lineHeight) / 4) + 1.0
-            
-            if let style = style {
-                self.addAttributes([.paragraphStyle: style, .baselineOffset: (baselineOffset)], range: range)
+        var maxLineHeight: CGFloat = 0.0
+        var firstFont: UIFont?
+        
+        self.enumerateAttribute(.font, in: NSRange(location: 0, length: self.length), options: []) { value, _, _ in
+            if let font = value as? UIFont {
+                // 적용된 폰트들을 비교해 maxLineHeight 저장
+                maxLineHeight = max(maxLineHeight, font.dealiLineHeight)
+                // baseLineOffset을 위해 첫번째 font 확인
+                if firstFont == nil { firstFont = font }
             }
         }
+        
+        guard let font = firstFont else { return self }
+        
+        let range = (source as NSString).range(of: source)
+        var style: NSMutableParagraphStyle?
+        if let paragraphStyle = self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle {
+            style = paragraphStyle
+        } else {
+            style = NSMutableParagraphStyle()
+        }
+        
+        style?.minimumLineHeight = maxLineHeight
+        style?.maximumLineHeight = maxLineHeight
+        
+        let baselineOffset = ((maxLineHeight - font.lineHeight) / 4) + 1.0
+        
+        if let style = style {
+            self.addAttributes([.paragraphStyle: style, .baselineOffset: baselineOffset], range: range)
+        }
+        
         return self
     }
     


### PR DESCRIPTION
- 여러개의 AttributedString을 append해서 사용해야하는 경우, 폰트사이즈에 차이가 있음에도, 처음 setLineHeight된 텍스트 폰트 기준 lineHeight가 지정되는 현상이 발생하였습니다. 
![image](https://github.com/user-attachments/assets/736e9878-8cdd-4d04-abb7-4a813b111737)

- maximum font의 LineHeight를 사용하도록 수정하여, 여러개의 AttString을 결합해 사용하는 케이스에 텍스트 잘림 없도록 개선하였습니다. 
**단, 모든 AttString을 append 한 뒤 가장 마지막에 setLineHeight를 적용해야합니다.**
![image](https://github.com/user-attachments/assets/3c44ce44-6080-4200-9558-30760e7477f8)
