### PR TITLE
[MP-5529] TextInput Reentrancy anomaly 발생하는 문제 개선

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/BottomSheetPopupTestViewController.swift
@@ -261,7 +261,7 @@ extension BottomSheetPopupTestViewController {
             $0.backgroundColor = .g05
         }
         
-        let textInput = DealiTextInput_v2()
+        let textInput = DealiTextInput()
         customView.addSubview(textInput)
         textInput.then {
             $0.placeholder = "텍스트필드"

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
@@ -110,11 +110,9 @@ final class TextInputValidationView: UIView {
         
         self.setupUI()
         
-        self.restrictedTextInput.rx.textEditingControlProperty
-            .orEmpty
-            .changed
-            .scan(self.restrictedTextInput.text ?? "") { _, current -> String in
-                
+        self.restrictedTextInput.rx.textEditingChanged
+            .scan(self.restrictedTextInput.text ?? "") { _, current -> String? in
+                guard let current else { return current }
                 self.restrictionOption.setErrorMessage(for: .alphabet, errorMessage: "알파벳 금지")
                 self.restrictionOption.setErrorMessage(for: .numeric, errorMessage: "숫자 금지")
                 self.restrictionOption.setErrorMessage(for: .korean, errorMessage:"한글 금지")

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
@@ -137,26 +137,6 @@ final class TextInputValidationView: UIView {
                 owner.restrictedTextInput.text = text
             }
             .disposed(by: self.disposeBag)
-        
-//        self.allowedTextInput.rx.textEditingControlProperty
-//            .orEmpty
-//            .changed
-//            .scan(self.allowedTextInput.text ?? "") { _, current -> String in
-//                
-//                let invalidOptionArray = [TextValidator(condition:.allow(self.allowingOption))].filter { !current.isValid(for: $0) }
-//                guard invalidOptionArray.first != nil else { return current }
-//                
-//                let filteredText: String = invalidOptionArray.reduce(current) { text, option -> String in
-//                    text.filteredText(for: option)
-//                }
-//                
-//                return filteredText
-//                
-//            }
-//            .bind(with: self) { owner, text in
-//                owner.allowedTextInput.text = text
-//            }
-//            .disposed(by: self.disposeBag)
     }
     
     required init?(coder: NSCoder) {

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController.swift
@@ -96,13 +96,13 @@ final class DealiPlaygroundViewController: UIViewController {
 final class TextInputValidationView: UIView {
     
     private let disposeBag = DisposeBag()
-    private let restrictedTextInput = DealiTextInput_v2()
+    private let restrictedTextInput = DealiTextInput()
     
 
     private var restrictionOption: DealiCharacterOptions = []
     
     // MARK: - ErrorMsg
-    private let allowedTextInput = DealiTextInput_v2()
+    private let allowedTextInput = DealiTextInput()
     private var allowingOption: DealiCharacterOptions = []
     
     override init(frame: CGRect) {

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController~.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/DealiPlaygroundViewController~.swift
@@ -131,10 +131,9 @@ final class TextInputValidationView: UIView {
                 }
 
             }
-            .map { text -> TextUpdateEvent in
-                return (text, false)
+            .bind(with: self) { owner, text in
+                owner.restrictedTextInput.text = text
             }
-            .bind(to: self.restrictedTextInput.rx.textWithEditingChanged)
             .disposed(by: self.disposeBag)
     }
     

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextAreaViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextAreaViewController.swift
@@ -185,7 +185,7 @@ final class TextAreaViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let disabledText = DealiTextInput_v2()
+        let disabledText = DealiTextInput()
         contentStackView.addArrangedSubview(disabledText)
         disabledText.then {
             $0.title = "Disabled Text Input"

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TextInputViewController.swift
@@ -13,8 +13,8 @@ import RxSwift
 final class TextInputViewController: UIViewController {
 
     private let contentScrollView = UIScrollView()
-    private let textInput = DealiTextInput_v2.text()
-    private let realTimeInput = DealiTextInput_v2.text()
+    private let textInput = DealiTextInput.text()
+    private let realTimeInput = DealiTextInput.text()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -106,7 +106,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let numberInput = DealiTextInput_v2.number()
+        let numberInput = DealiTextInput.number()
         contentStackView.addArrangedSubview(numberInput)
         numberInput.then {
             $0.title = "숫자 텍스트 입력"
@@ -120,7 +120,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let emailInput = DealiTextInput_v2.email()
+        let emailInput = DealiTextInput.email()
         contentStackView.addArrangedSubview(emailInput)
         emailInput.then {
             $0.title = "이메일 텍스트 입력"
@@ -136,7 +136,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let urlInput = DealiTextInput_v2.url()
+        let urlInput = DealiTextInput.url()
         contentStackView.addArrangedSubview(urlInput)
         urlInput.then {
             $0.title = "urlText 입력"
@@ -152,7 +152,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let phoneInput = DealiTextInput_v2.phone()
+        let phoneInput = DealiTextInput.phone()
         contentStackView.addArrangedSubview(phoneInput)
         phoneInput.then {
             $0.title = "폰번호 텍스트 입력"
@@ -163,7 +163,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let priceInput = DealiTextInput_v2.price()
+        let priceInput = DealiTextInput.price()
         contentStackView.addArrangedSubview(priceInput)
         priceInput.then {
             $0.title = "가격 텍스트 입력"
@@ -174,7 +174,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let passwordInput = DealiTextInput_v2.password()
+        let passwordInput = DealiTextInput.password()
         contentStackView.addArrangedSubview(passwordInput)
         passwordInput.then {
             $0.title = "패스워드 텍스트 입력"
@@ -184,7 +184,7 @@ final class TextInputViewController: UIViewController {
             $0.left.right.equalToSuperview()
         }
         
-        let disabledInput = DealiTextInput_v2()
+        let disabledInput = DealiTextInput()
         contentStackView.addArrangedSubview(disabledInput)
         disabledInput.then {
             $0.title = "비활성 텍스트인풋"

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TypographyViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/ViewControllers/Sub/TypographyViewController.swift
@@ -16,7 +16,7 @@ import DealiDesignKit
 final class TypographyViewController: UIViewController {
     
     private var disposeBag = DisposeBag()
-    private let textInput = DealiTextInput_v2()
+    private let textInput = DealiTextInput()
     
     var text: String? {
         didSet {

--- a/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
+++ b/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
@@ -33,3 +33,5 @@ public enum ETextFieldStatus: Equatable {
     case disabled
     case readOnly
 }
+
+public typealias TextUpdateEvent = (text: String?, withEditingChanged: Bool)

--- a/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
+++ b/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
@@ -17,6 +17,7 @@ public protocol DealiTextField: AnyObject {
     
     associatedtype T: UITextInput
     var textField: T { get }
+    var text: String? { get set }
 }
 
 protocol DealiTextFieldConfig {

--- a/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
+++ b/Sources/DealiDesignKit/Components/TextField/DealiTextField.swift
@@ -13,7 +13,7 @@ import RxCocoa
  텍스트 필드(Text Fields)는 사용자가 텍스트 입력 및 확인 시 활용되는 컴포넌트입니다.
  한 줄 입력인 텍스트 필드(Input)와 여러 줄 입력인 텍스트 영역(Text Area)으로 나뉩니다.
  */
-public protocol DealiTextField {
+public protocol DealiTextField: AnyObject {
     
     associatedtype T: UITextInput
     var textField: T { get }

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DeailTextInputConfig.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DeailTextInputConfig.swift
@@ -70,45 +70,45 @@ struct DeailTextInputPasswordConfig: DeailTextInputConfigureProtocol {
 }
 
 
-extension DealiTextInput_v2 {
-    public static func text() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+extension DealiTextInput {
+    public static func text() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputTextConfig())
         return textInput
     }
     
-    public static func email() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func email() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputEmailConfig())
         return textInput
     }
     
-    public static func number() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func number() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputNumberConfig())
         return textInput
     }
     
-    public static func phone() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func phone() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputPhoneConfig())
         return textInput
     }
     
-    public static func price() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func price() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputPriceConfig())
         return textInput
     }
     
-    public static func url() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func url() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputUrlConfig())
         return textInput
     }
     
-    public static func password() -> DealiTextInput_v2 {
-        let textInput = DealiTextInput_v2()
+    public static func password() -> DealiTextInput {
+        let textInput = DealiTextInput()
         textInput.configure(configure: DeailTextInputPasswordConfig())
         return textInput
     }

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
@@ -1,5 +1,5 @@
 //
-//  DealiTextInput_v2.swift
+//  DealiTextInput.swift
 //
 //
 //  Created by hoji on 2023/11/01.
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-open class DealiTextInput_v2: UIView, DealiTextField {
+open class DealiTextInput: UIView, DealiTextField {
     
     public private(set) var textField = UITextField()
     
@@ -390,7 +390,7 @@ open class DealiTextInput_v2: UIView, DealiTextField {
 }
 
 // MARK: - UITextFieldDelegate
-extension DealiTextInput_v2: UITextFieldDelegate {
+extension DealiTextInput: UITextFieldDelegate {
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         guard self.textInputFormat == .price else { return true }
         
@@ -416,7 +416,7 @@ extension DealiTextInput_v2: UITextFieldDelegate {
 }
 
 // MARK: - UI Configuration
-extension DealiTextInput_v2: DealiTextFieldConfig {
+extension DealiTextInput: DealiTextFieldConfig {
     func setUI() {
         self.do {
             $0.backgroundColor = .primary04

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
@@ -11,6 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+
 open class DealiTextInput: UIView, DealiTextField {
     
     public private(set) var textField = UITextField()

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
@@ -99,20 +99,15 @@ open class DealiTextInput_v2: UIView, DealiTextField {
         } set {
             if self.textField.text != newValue {
                 self.textField.text = newValue
-                
-                guard inputStatus != .readOnly && inputStatus != .disabled else { return }
-                self.sendAdditionalEditingEvents()
             }
         }
     }
     
-    private func sendAdditionalEditingEvents() {
-        if self.sendValuedChagedActionInSetter {
-            self.textField.sendActions(for: .valueChanged)
-            
-            if self.inputStatus != .focusIn {
-                self.textField.sendActions(for: .editingDidEnd)
-            }
+    public func sendEditingEvents() {
+        self.textField.sendActions(for: .editingChanged)
+        
+        if self.inputStatus != .focusIn {
+            self.textField.sendActions(for: .editingDidEnd)
         }
     }
     
@@ -223,31 +218,6 @@ open class DealiTextInput_v2: UIView, DealiTextField {
                 $0.centerY.equalToSuperview()
             }
         }
-    }
-    
-    // MARK:  Reactive Event Stream
-    /// 포커스 아웃 이벤트 모두 담은 Driver
-    @available(*, deprecated, renamed: "rx.editingDidFinish")
-    public var textFieldDidEndEditing: Driver<Bool>!
-    /// return, next 키 등 눌렀을 때 포커스 조정 등의 처리를 위한 Driver
-    @available(*, deprecated, renamed: "rx.editingDidEndOnExit")
-    public var editingDidEndOnExit: Driver<Void>!
-    @available(*, deprecated, renamed: "rx.editingDidEnd")
-    public var editingDidEnd: Driver<Void>!
-    /// 입력 시마다 불리는 stream
-    @available(*, deprecated, renamed: "rx.textEditingControlProperty")
-    public var changedTextControlProperty: ControlProperty<String?> {
-        return self.textField.rx.controlProperty(
-            editingEvents: [.editingChanged, .valueChanged],
-            getter: { textField in
-                textField.text
-            },
-            setter: { textField, value in
-                if self.textField.text != value {
-                    self.textField.text = value
-                }
-            }
-        )
     }
     
     // MARK: Keyboard, Resonponder
@@ -400,6 +370,7 @@ open class DealiTextInput_v2: UIView, DealiTextField {
             .bind(with: self) { owner, _ in
                 owner.text = nil
                 owner.clearButton.isHidden = true
+                owner.sendEditingEvents()
             }
             .disposed(by: self.disposeBag)
         

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
@@ -101,18 +101,21 @@ open class DealiTextInput_v2: UIView, DealiTextField {
                 self.textField.text = newValue
                 
                 guard inputStatus != .readOnly && inputStatus != .disabled else { return }
-                
-                if self.sendValuedChagedActionInSetter {
-                    self.textField.sendActions(for: .valueChanged)
-                    
-                    if self.inputStatus != .focusIn {
-                        self.textField.sendActions(for: .editingDidEnd)
-                    }
-                }
-                
+                self.sendAdditionalEditingEvents()
             }
         }
     }
+    
+    private func sendAdditionalEditingEvents() {
+        if self.sendValuedChagedActionInSetter {
+            self.textField.sendActions(for: .valueChanged)
+            
+            if self.inputStatus != .focusIn {
+                self.textField.sendActions(for: .editingDidEnd)
+            }
+        }
+    }
+    
     public var font: UIFont = .b2r14 {
         didSet {
             self.textField.font = self.font

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput_v2.swift
@@ -15,10 +15,6 @@ open class DealiTextInput_v2: UIView, DealiTextField {
     
     public private(set) var textField = UITextField()
     
-    /// 값을 직접 setter 에서 할당 시 valueChanged 액션을 트리거할지 여부. default는 true
-    public var sendValuedChagedActionInSetter: Bool = true
-
-    
     // MARK: - PUBLIC
     public init() {
         super.init(frame: .zero)
@@ -103,7 +99,15 @@ open class DealiTextInput_v2: UIView, DealiTextField {
         }
     }
     
-    public func sendEditingEvents() {
+    /// text 를 할당하고 `editingChanged`  호출하고 싶을 때 사용
+    /// - Parameter text: 넣고자 하는 Text
+    public func initText(_ text: String? = nil) {
+        self.text = text
+        self.sendEditingEvents()
+    }
+    
+    private func sendEditingEvents() {
+        guard inputStatus != .readOnly && inputStatus != .disabled else { return }
         self.textField.sendActions(for: .editingChanged)
         
         if self.inputStatus != .focusIn {

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -35,7 +35,7 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
             getter: { textField in
                 textField.text
             },
-            setter:  { textField, value in
+            setter: { textField, value in
                 if base.text != value {
                     base.text = value
                 }

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -35,12 +35,7 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
             getter: { textField in
                 textField.text
             },
-            setter: { textField, value in
-                if base.textField.text != value {
-                    base.textField.text = value
-                }
-            }
+            setter: { _, _ in }
         )
     }
-    
 }

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -38,4 +38,10 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
             setter: { _, _ in }
         )
     }
+    
+    public var textEditingChanged: Observable<String?> {
+        return base.textField.rx.controlEvent([.editingChanged, .valueChanged]).map { _ in
+            return base.textField.text
+        }
+    }
 }

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -35,13 +35,18 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
             getter: { textField in
                 textField.text
             },
-            setter: { _, _ in }
+            setter:  { textField, value in
+                if base.text != value {
+                    base.text = value
+                }
+            }
+
         )
     }
     
     public var textEditingChanged: Observable<String?> {
-        return base.textField.rx.controlEvent([.editingChanged, .valueChanged]).map { _ in
-            return base.textField.text
+        return base.textField.rx.controlEvent([.editingChanged]).map { _ in
+            return base.text
         }
     }
 }

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -29,6 +29,8 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
         return base.textField.rx.controlEvent([.editingDidEnd, .editingDidEndOnExit])
     }
     
+    
+    @available(*, deprecated, message: "Use textEditingChanged instead")
     public var textEditingControlProperty: ControlProperty<String?> {
         return base.textField.rx.controlProperty(
             editingEvents: [.editingChanged],
@@ -40,7 +42,6 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
                     base.text = value
                 }
             }
-
         )
     }
     
@@ -49,4 +50,21 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
             return base.text
         }
     }
+    
 }
+
+extension Reactive where Base: DealiTextInput {
+    /// 텍스트 적용 시 editingChanged 이벤트 방출도 가능한 Binder
+    public var textWithEditingChanged: Binder<(text: String?, withEditingChanged: Bool)> {
+        return Binder(self.base) { base, value in
+            guard base.text != value.text else { return }
+            
+            if value.withEditingChanged {
+                base.initText(value.text)
+            } else {
+                base.text = value.text
+            }
+        }
+    }
+}
+

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -55,7 +55,7 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
 
 extension Reactive where Base: DealiTextInput {
     /// 텍스트 적용 시 editingChanged 이벤트 방출도 가능한 Binder
-    public var textWithEditingChanged: Binder<(text: String?, withEditingChanged: Bool)> {
+    public var textWithEditingChanged: Binder<TextUpdateEvent> {
         return Binder(self.base) { base, value in
             guard base.text != value.text else { return }
             

--- a/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/Reactive+Extension/Reactive+DealiTextInput.swift
@@ -31,7 +31,7 @@ extension Reactive where Base: DealiTextField, Base.T == UITextField {
     
     public var textEditingControlProperty: ControlProperty<String?> {
         return base.textField.rx.controlProperty(
-            editingEvents: [.editingChanged, .valueChanged],
+            editingEvents: [.editingChanged],
             getter: { textField in
                 textField.text
             },


### PR DESCRIPTION
## PR 마감기한

## 작업 내용
- DealiTextInput 에서 사용자 입력이 지연되는 일부 경우에서 text setter 에서 `valueChanged` 액션을 보내면서 검증로직을 다시 타고, 다시 값을 보내고 반복되는 Reentrancy anomaly 문제가 발생하여
- TextInput 에서 값을 할당하고 검증로직까지 타게 하고 싶은 경우에는 `initText()` 함수를 사용하여 명시적으로 값을 할당하고, `editingChanged` 액션을 보내게끔 변경하였습니다.

## Merge 전 필요한 작업
- 신마 프로젝트에 적용 후 열띤 테스트

## 주의해서 봐야 할 부분
- 문제 없는지 테스트 해주세요
