### PR TITLE
DealiPlaceholder border layer 개선

### DIFF
--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -225,25 +225,21 @@ open class DealiPlaceholderImageView: UIImageView {
         
         let radius = self.viewShape.getRadius(for: self.bounds.size.height)
         
-        let borderLayer = CAShapeLayer()
         let maskLayer = CAShapeLayer()
         maskLayer.frame = bounds
         
-        let borderRect = bounds.insetBy(dx: self.viewShape.borderWidth / 2, dy: self.viewShape.borderWidth / 2)
-        let cornerRadiiSize = CGSize(width: radius, height: radius)
-        
         switch self.viewShape {
         case .rectangle(let corners):
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
-            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
         default:
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
-            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
         }
         
         self.layer.mask = maskLayer
         
         // Add border
+        let borderLayer = CAShapeLayer()
+        borderLayer.path = maskLayer.path // Reuse the Bezier path
         borderLayer.fillColor = UIColor.clear.cgColor
         borderLayer.strokeColor = self.viewShape.borderColor
         borderLayer.lineWidth = self.viewShape.borderWidth

--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -227,21 +227,25 @@ open class DealiPlaceholderImageView: UIImageView {
         
         let radius = self.viewShape.getRadius(for: self.bounds.size.height)
         
+        let borderLayer = CAShapeLayer()
         let maskLayer = CAShapeLayer()
         maskLayer.frame = bounds
         
+        let borderRect = bounds.insetBy(dx: self.viewShape.borderWidth / 2, dy: self.viewShape.borderWidth / 2)
+        let cornerRadiiSize = CGSize(width: radius, height: radius)
+        
         switch self.viewShape {
         case .rectangle(let corners):
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
+            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
         default:
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
+            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
         }
         
         self.layer.mask = maskLayer
         
         // Add border
-        let borderLayer = CAShapeLayer()
-        borderLayer.path = maskLayer.path // Reuse the Bezier path
         borderLayer.fillColor = UIColor.clear.cgColor
         borderLayer.strokeColor = self.viewShape.borderColor
         borderLayer.lineWidth = self.viewShape.borderWidth

--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -151,8 +151,6 @@ open class DealiPlaceholderImageView: UIImageView {
             }
         default:
             self.backgroundColor = self.backgroundStyle.backgroundColor
-            self.layer.borderWidth = self.viewShape.borderWidth
-            self.layer.borderColor = self.viewShape.borderColor
             
             guard let placeholderImage = UIImage.dealiIcon(named: self.imageStyle.placeholderImageName)?.withTintColor(self.backgroundStyle.imageColor) else { return }
             self.placeholderImageView.image = placeholderImage

--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -225,21 +225,25 @@ open class DealiPlaceholderImageView: UIImageView {
         
         let radius = self.viewShape.getRadius(for: self.bounds.size.height)
         
+        let borderLayer = CAShapeLayer()
         let maskLayer = CAShapeLayer()
         maskLayer.frame = bounds
         
+        let borderRect = bounds.insetBy(dx: self.viewShape.borderWidth / 2, dy: self.viewShape.borderWidth / 2)
+        let cornerRadiiSize = CGSize(width: radius, height: radius)
+        
         switch self.viewShape {
         case .rectangle(let corners):
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
+            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: corners, cornerRadii: cornerRadiiSize).cgPath
         default:
-            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: CGSize(width: radius, height: radius)).cgPath
+            maskLayer.path = UIBezierPath(roundedRect: bounds, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
+            borderLayer.path = UIBezierPath(roundedRect: borderRect, byRoundingCorners: .allCorners, cornerRadii: cornerRadiiSize).cgPath
         }
         
         self.layer.mask = maskLayer
         
         // Add border
-        let borderLayer = CAShapeLayer()
-        borderLayer.path = maskLayer.path // Reuse the Bezier path
         borderLayer.fillColor = UIColor.clear.cgColor
         borderLayer.strokeColor = self.viewShape.borderColor
         borderLayer.lineWidth = self.viewShape.borderWidth


### PR DESCRIPTION
## PR 마감기한
도매매장차별화에 반영 희망

## 작업 내용
- border layer를 코너에서 잘리지 않고 노출될 수 있도록 수정 함
- layer.border를 제거해서 코너가 아닌 부분에서 border가 겹쳐서 노출되지 않도록 함

## 수정 전
![스크린샷, 2025-03-20 오전 11 26 48](https://github.com/user-attachments/assets/af064cb2-9389-4d8c-a40d-7cd3f951d32c)


## 수정 후
![스크린샷, 2025-03-20 오전 11 00 49](https://github.com/user-attachments/assets/4823eed1-5cba-470a-881d-1e7d6bd11eae)
