### PR TITLE
[MP-5597] 버튼 width 계산 에러 수정

### DIFF
--- a/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
+++ b/Sources/DealiDesignKit/Components/Control/ButtonComponent.swift
@@ -743,7 +743,7 @@ public struct ClickableImage {
     public init(dealiIconName: String, needOriginColor: Bool = false) {
         self.named = dealiIconName
         self.needOriginColor = needOriginColor
-        self.uiImage = UIImage.dealiIcon(named: dealiIconName)
+        self.uiImage = UIImage.dealiIcon(named: dealiIconName)?.resize(CGSize(width: 16.0, height: 16.0))
     }
     public init(_ image: UIImage?, needOriginColor: Bool = false) {
         self.named = ""


### PR DESCRIPTION
## PR 마감기한
2025.03.31 (월)

## 작업 내용
- 신상캐시 수동충전 기능개발 후 디자인QA 중에, 다음과 같은 디자인 QA 가 들어왔는데
<img width="434" alt="스크린샷 2025-03-31 오후 4 46 56" src="https://github.com/user-attachments/assets/d9ff5116-1008-47cc-8902-fb5be086c05a" />

- 보다 보니 leftIcon, rightIcon 이미지를 받을 때 시스템 리소스를 쓰는 과정에서 아이콘 사이즈가 24로 계산되는 것을 발견하여 수정하였습니다.

## Merge 전 필요한 작업
- N/A

## 주의해서 봐야 할 부분
