### PR TITLE
[MP-5651] DealiPlaceholderImageView NaN Error 수정

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/xcshareddata/xcschemes/DealiDesignSystemSampleApp.xcscheme
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/xcshareddata/xcschemes/DealiDesignSystemSampleApp.xcscheme
@@ -50,6 +50,13 @@
             ReferencedContainer = "container:DealiDesignSystemSampleApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CG_NUMERICS_SHOW_BACKTRACE"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -229,7 +229,11 @@ open class DealiPlaceholderImageView: UIImageView {
         let maskLayer = CAShapeLayer()
         maskLayer.frame = bounds
         
-        let borderRect = bounds.insetBy(dx: self.viewShape.borderWidth / 2, dy: self.viewShape.borderWidth / 2)
+        let halfBorder = self.viewShape.borderWidth / 2
+        let maxInset = min(bounds.width / 2, bounds.height / 2)
+        let safeInset = min(halfBorder, maxInset)
+        
+        let borderRect = bounds.insetBy(dx: safeInset, dy: safeInset)
         let cornerRadiiSize = CGSize(width: radius, height: radius)
         
         switch self.viewShape {


### PR DESCRIPTION
## PR 마감기한
2025.04.15 (화)

## 작업 내용
- DealiPlaceholder에서 발생하는 NaN Error 를 수정했습니다.
- 원인은 width나 height가 0일때 보더를 주기 위한 borderRect 를 생성하는 과정에서 inset 값을 주면서, origin의 x, y 값이 0보다 작아지는 것이 문제였습니다. 

## Merge 전 필요한 작업
- N/A
