### PR TITLE
[MP-5749] BottomSheet 리스트 항목 선택 액션 처리 타이밍 수정

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		39AE99782CF47D8B007CF381 /* DealiTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AE99752CF47D8B007CF381 /* DealiTabBarViewController.swift */; };
 		39AE997A2CF47D9E007CF381 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AE99792CF47D9E007CF381 /* TabBarViewController.swift */; };
 		39F6D2442D197568008B35A9 /* PlaceholderImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D2432D197568008B35A9 /* PlaceholderImageViewController.swift */; };
+		39FE39C32DE6AAB1005E0CB5 /* LinkLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FE39C22DE6AAB1005E0CB5 /* LinkLabelViewController.swift */; };
 		4D1FA9292AFC778E00AA510F /* SwitchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1FA9282AFC778E00AA510F /* SwitchViewController.swift */; };
 		4D50A85D2DAF4F3500A39FB0 /* ComponentHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D50A85C2DAF4F3500A39FB0 /* ComponentHeaderView.swift */; };
 		4D50A85F2DAF543300A39FB0 /* SearchBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D50A85E2DAF543300A39FB0 /* SearchBarCell.swift */; };
@@ -43,7 +44,6 @@
 		4DA7ED842DA79F850029165D /* ComponentSectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7ED832DA79F850029165D /* ComponentSectionData.swift */; };
 		4DA7ED872DA7AA390029165D /* ActionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7ED862DA7AA390029165D /* ActionManager.swift */; };
 		4DA7ED892DA7AECE0029165D /* ComponentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7ED882DA7AECE0029165D /* ComponentCollectionViewCell.swift */; };
-		4DB2D6F42AFB281100DFF053 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2D6F32AFB281100DFF053 /* BottomSheetViewController.swift */; };
 		4DE326202CDB61CF00E67FEC /* ImageChipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE3261F2CDB61CF00E67FEC /* ImageChipViewController.swift */; };
 		4DF5ABEB2CC25E1300BFB7D6 /* ColorItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF5ABEA2CC25E1300BFB7D6 /* ColorItemView.swift */; };
 		4DFE8C612BE4AF140063A15E /* TextAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFE8C602BE4AF140063A15E /* TextAreaViewController.swift */; };
@@ -84,6 +84,7 @@
 		39AE99752CF47D8B007CF381 /* DealiTabBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DealiTabBarViewController.swift; sourceTree = "<group>"; };
 		39AE99792CF47D9E007CF381 /* TabBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		39F6D2432D197568008B35A9 /* PlaceholderImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderImageViewController.swift; sourceTree = "<group>"; };
+		39FE39C22DE6AAB1005E0CB5 /* LinkLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkLabelViewController.swift; sourceTree = "<group>"; };
 		4D1FA9282AFC778E00AA510F /* SwitchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewController.swift; sourceTree = "<group>"; };
 		4D50A85C2DAF4F3500A39FB0 /* ComponentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentHeaderView.swift; sourceTree = "<group>"; };
 		4D50A85E2DAF543300A39FB0 /* SearchBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarCell.swift; sourceTree = "<group>"; };
@@ -156,6 +157,7 @@
 				4DA7ED782DA668560029165D /* 1. Token */,
 				4DA7ED7B2DA6694A0029165D /* 2. Atom */,
 				4DA7ED792DA668660029165D /* 3. Molecule */,
+				39FE39C12DE6AA6C005E0CB5 /* 4.Etc */,
 				04AD45112A15EF1000093BEB /* Others */,
 			);
 			path = DealiDesignSystemSampleApp;
@@ -195,6 +197,14 @@
 				39AE99752CF47D8B007CF381 /* DealiTabBarViewController.swift */,
 			);
 			path = DealiTabBarViewController;
+			sourceTree = "<group>";
+		};
+		39FE39C12DE6AA6C005E0CB5 /* 4.Etc */ = {
+			isa = PBXGroup;
+			children = (
+				39FE39C22DE6AAB1005E0CB5 /* LinkLabelViewController.swift */,
+			);
+			path = 4.Etc;
 			sourceTree = "<group>";
 		};
 		4D584A1C2D1A82A1007BB775 /* Notice */ = {
@@ -441,6 +451,7 @@
 				4DA7ED892DA7AECE0029165D /* ComponentCollectionViewCell.swift in Sources */,
 				E6C115E52BE4855A00032960 /* IndicatorViewController.swift in Sources */,
 				390D485B2C88456B00C30C0E /* FontComponentViewController.swift in Sources */,
+				39FE39C32DE6AAB1005E0CB5 /* LinkLabelViewController.swift in Sources */,
 				4D58315E2B033EC4009F7B48 /* SliderBarViewController.swift in Sources */,
 				3990E48D2CC61E90007C2D9E /* LabeledTextComponentViewController.swift in Sources */,
 				FC0838872D06C0DB0028AE27 /* TextLinkViewController.swift in Sources */,

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/0. Main/ComponentSectionData.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/0. Main/ComponentSectionData.swift
@@ -59,6 +59,8 @@ enum ActionType: Hashable {
     case notice
     case tabBar
     
+    // MARK: - etc
+    case linkLabel
 }
 
 extension ItemData {
@@ -121,6 +123,9 @@ extension ItemData {
             NoticeViewController()
         case .tabBar:
             TabBarViewController()
+            
+        case .linkLabel:
+            LinkLabelViewController()
         }
     }
 }

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/0. Main/MainViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/0. Main/MainViewController.swift
@@ -16,12 +16,14 @@ final class MainViewController: UIViewController {
         case token
         case atom
         case molcule
+        case etc
     }
     
     lazy var componentSectionData: [Int: ComponentSectionData] = [
         Section.token.rawValue : tokenSectionData,
         Section.atom.rawValue: atomSectionData,
-        Section.molcule.rawValue: molculeSectionData
+        Section.molcule.rawValue: molculeSectionData,
+        Section.etc.rawValue: etcSectionData
     ]
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.compositionalLayout)
@@ -29,7 +31,7 @@ final class MainViewController: UIViewController {
     private lazy var compositionalLayout: UICollectionViewLayout = {
         UICollectionViewCompositionalLayout { sectionIndex, env in
             switch Section(rawValue: sectionIndex) {
-            case .token, .atom, .molcule:
+            case .token, .atom, .molcule, .etc:
                 return self.componentLayout()
             default:
                 return self.singleItemLayout()
@@ -110,6 +112,14 @@ final class MainViewController: UIViewController {
             
         ]
     )
+    
+    var etcSectionData =
+    ComponentSectionData(
+        title: "Etc",
+        items: [
+            ItemData(title: "LinkLabel", type: .linkLabel),
+        ]
+    )
 }
 
 private extension MainViewController {
@@ -161,7 +171,7 @@ extension MainViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let sectionIdentifier = dataSource.sectionIdentifier(for: indexPath.section)
         switch sectionIdentifier {
-        case .token, .atom, .molcule:
+        case .token, .atom, .molcule, .etc:
             guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
             self.handleAction(with: item)
         default:
@@ -179,7 +189,7 @@ extension MainViewController {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchBarCell.identifier, for: indexPath) as! SearchBarCell
                 cell.searchInput.delegate = self
                 return cell
-            case .token, .atom, .molcule:
+            case .token, .atom, .molcule, .etc:
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ComponentCollectionViewCell.identifier, for: indexPath) as! ComponentCollectionViewCell
                 cell.configure(itemIdentifier)
                 
@@ -198,7 +208,7 @@ extension MainViewController {
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
 
             switch section {
-            case .token, .atom, .molcule:
+            case .token, .atom, .molcule, .etc:
                 let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ComponentHeaderView.identifier, for: indexPath) as! ComponentHeaderView
 
                 if let sectionData = self.componentSectionData[section.rawValue] {

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/3. Molecule/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/3. Molecule/BottomSheetPopupTestViewController.swift
@@ -190,7 +190,8 @@ extension BottomSheetPopupTestViewController {
                                                         
         DealiBottomSheet.showSingleSelectionType(
             titleType: .titleCloseButton(title: "단일선택 바텀시트"),
-            option: optionData, 
+            option: optionData,
+            shouldDismissWhenSelect: true,
             popupPresentingViewController: self,
             selectAction: { indecies in
                 debugPrint("눌림:\(indecies)")

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/4.Etc/LinkLabelViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/4.Etc/LinkLabelViewController.swift
@@ -1,0 +1,127 @@
+//
+//  LinkLabelViewController.swift
+//  DealiDesignSystemSampleApp
+//
+//  Created by 이창호 on 5/28/25.
+//  Copyright © 2025 Dealicious Inc. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import DealiDesignKit
+
+final class LinkLabelViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    
+    private let oneLinkLabel = UILabel()
+    private let multiLineOneLinkLabel = UILabel()
+    private let multiLinkLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.title = "Link Label"
+        self.view.backgroundColor = .primary04
+
+        self.subscribe()
+    }
+
+    override func loadView() {
+        super.loadView()
+        
+        let contentScrollView = UIScrollView()
+        self.view.addSubview(contentScrollView)
+        contentScrollView.then {
+            $0.bounces = false
+        }.snp.makeConstraints {
+            $0.top.bottom.left.right.equalToSuperview()
+        }
+        
+        let contentView = UIView()
+        contentScrollView.addSubview(contentView)
+        contentView.then {
+            $0.backgroundColor = .clear
+        }.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+        
+        let contentStackView = UIStackView()
+        contentView.addSubview(contentStackView)
+        contentStackView.then {
+            $0.axis = .vertical
+            $0.spacing = 10.0
+            $0.alignment = .center
+            $0.distribution = .equalSpacing
+        }.snp.makeConstraints {
+            $0.top.bottom.left.right.equalToSuperview().inset(20.0)
+        }
+        
+        contentStackView.addArrangedSubview(self.oneLinkLabel)
+        self.oneLinkLabel.then {
+            $0.attributedText = NSMutableAttributedString(string: "주문 완료 시, 사장님의 개인정보를 제3자(도매)에게 제공합니다.")
+                .font(.b1r15)
+                .color(.g70)
+                .alignment(.left)
+                .applyLinkStyle(for: TextStyleAttributes(text: "제3자(도매)", font: .b1sb15, color: .g70))
+                .setLineHeight()
+            $0.numberOfLines = 0
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+
+        contentStackView.addArrangedSubview(self.multiLineOneLinkLabel)
+        self.multiLineOneLinkLabel.then {
+            $0.attributedText = NSMutableAttributedString(string: "1. 개인정보 수집근거 : 개인정보보호법 제15조 제1항 제4호\n2. 수집하는 항목 : 받는사람, 주소, 대표전화\n3. 수집목적 : 구매한 상품 배송\n4. 보유 및 이용 기간 : 배송지 삭제 또는 회원 탈퇴 시까지 (단, 관련 법에 의해 필요한 경우 법에 명시된 기간까지 보유)")
+                .font(.b1r15)
+                .color(.g50)
+                .alignment(.left)
+                .applyLinkStyle(for: TextStyleAttributes(text: "관련 법에 의해", font: .b1sb15))
+                .setLineHeight()
+            $0.numberOfLines = 0
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+        
+        contentStackView.addArrangedSubview(self.multiLinkLabel)
+        self.multiLinkLabel.then {
+            $0.attributedText = NSMutableAttributedString(string: "1. 개인정보 수집근거 : 개인정보보호법 제15조 제1항 제4호\n2. 수집하는 항목\n- 사입사 방문시 : 사입사 연락처\n- 택배배송 요청시 : 받는사람, 배송지 주소, 수령인 연락처\n- 계좌이체 결제시 : 입금자명\n3. 수집하는 목적 : 상품 구매 및 배송\n4. 보유기간 : 주문방법 정보 삭제 또는 회원 탈퇴 시까지 (단, 관련 법에 의해 필요한 경우 법에 명시된 기간까지 보유)")
+                .font(.b1r15)
+                .color(.g100)
+                .alignment(.left)
+                .applyMultipleLinkStyle(for: [TextStyleAttributes(text: "사입사 방문시", font: .b1sb15, color: .g70),
+                                              TextStyleAttributes(text: "택배배송 요청시", font: .b1sb15),
+                                              TextStyleAttributes(text: "계좌이체 결제시", font: .b1sb15, color: .g80)])
+                .setLineHeight()
+            $0.numberOfLines = 0
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
+    }
+    
+    private func subscribe() {
+        self.oneLinkLabel.rx.tapGesture().when(.recognized).bind(with: self) { owner, gesture in
+            let location = gesture.location(in: owner.oneLinkLabel)
+            if let linkText = owner.oneLinkLabel.tappedLinkText(at: location) {
+                print("oneLinkLabel linkText = \(linkText)")
+            }
+        }.disposed(by: self.disposeBag)
+        
+        self.multiLineOneLinkLabel.rx.tapGesture().when(.recognized).bind(with: self) { owner, gesture in
+            let location = gesture.location(in: owner.multiLineOneLinkLabel)
+            if let linkText = owner.multiLineOneLinkLabel.tappedLinkText(at: location) {
+                print("multiLineOneLinkLabel linkText = \(linkText)")
+            }
+        }.disposed(by: self.disposeBag)
+        
+        self.multiLinkLabel.rx.tapGesture().when(.recognized).bind(with: self) { owner, gesture in
+            let location = gesture.location(in: owner.multiLinkLabel)
+            if let linkText = owner.multiLinkLabel.tappedLinkText(at: location) {
+                print("multiLinkLabel linkText = \(linkText)")
+            }
+        }.disposed(by: self.disposeBag)
+    }
+
+}

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -463,13 +463,16 @@ extension DealiBottomSheetSystemViewController: UICollectionViewDataSource {
             var uiModel = DealiBottomSheetSingleSelectCellUIModel.map(optionData: self.optionData[indexPath.item])
             uiModel.selectedActionHandler = { [weak self] in
                 guard let self else { return }
-                self.selectAction?([indexPath.item])
-                self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
-                self.optionData[indexPath.item].isSelected = true
-                self.collectionView.reloadData()
                 
                 if self.shouldDismissWhenSelect {
-                    self.hideBottomSheet()
+                    self.hideBottomSheet {
+                        self.selectAction?([indexPath.item])
+                    }
+                } else {
+                    self.selectAction?([indexPath.item])
+                    self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
+                    self.optionData[indexPath.item].isSelected = true
+                    self.collectionView.reloadData()
                 }
             }
             
@@ -500,13 +503,16 @@ extension DealiBottomSheetSystemViewController: UICollectionViewDataSource {
             var uiModel = DealiBottomSheetIconWithTextCellUIModel.map(optionData: self.optionData[indexPath.item])
             uiModel.selectedActionHandler = { [weak self] in
                 guard let self else { return }
-                self.selectAction?([indexPath.item])
-                self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
-                self.optionData[indexPath.item].isSelected = true
-                self.collectionView.reloadData()
                 
                 if self.shouldDismissWhenSelect {
-                    self.hideBottomSheet()
+                    self.hideBottomSheet {
+                        self.selectAction?([indexPath.item])
+                    }
+                } else {
+                    self.selectAction?([indexPath.item])
+                    self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
+                    self.optionData[indexPath.item].isSelected = true
+                    self.collectionView.reloadData()
                 }
             }
             
@@ -518,13 +524,16 @@ extension DealiBottomSheetSystemViewController: UICollectionViewDataSource {
             
             uiModel.selectedActionHandler = { [weak self] in
                 guard let self else { return }
-                self.selectAction?([indexPath.item])
-                self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
-                self.optionData[indexPath.item].isSelected = true
-                self.collectionView.reloadData()
                 
                 if self.shouldDismissWhenSelect {
-                    self.hideBottomSheet()
+                    self.hideBottomSheet {
+                        self.selectAction?([indexPath.item])
+                    }
+                } else {
+                    self.selectAction?([indexPath.item])
+                    self.optionData = self.optionData.map { DealiBottomSheetOptionData(optionName: $0.optionName) }
+                    self.optionData[indexPath.item].isSelected = true
+                    self.collectionView.reloadData()
                 }
             }
             cell.configure(with: uiModel)

--- a/Sources/DealiDesignKit/Utils/Constant.swift
+++ b/Sources/DealiDesignKit/Utils/Constant.swift
@@ -14,3 +14,5 @@ public var safeAreaBottomMargin: CGFloat {
     }
     return 0
 }
+
+public let TEXT_LINK: String = "TextLink"

--- a/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
@@ -11,11 +11,13 @@ public struct TextStyleAttributes {
     var text: String
     var font: UIFont?
     var color: UIColor?
+    var underline: Bool
     
-    public init(text: String, font: UIFont? = nil, color: UIColor? = nil) {
+    public init(text: String, font: UIFont? = nil, color: UIColor? = nil, underline: Bool = true) {
         self.text = text
         self.font = font
         self.color = color
+        self.underline = underline
     }
 }
 
@@ -272,5 +274,73 @@ public extension NSMutableAttributedString {
                                                      options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return self.htmlString(htmlString, fontSize: fontSize)
+    }
+    
+    func applyLinkStyle(for linkStyle: TextStyleAttributes) -> NSMutableAttributedString {
+        let source = self.string
+        guard source.isEmpty == false, source.contains(linkStyle.text) else { return self }
+        
+        let range = (source as NSString).range(of: linkStyle.text)
+        
+        // 기존에 적용된 색상 가져오기 (없으면 systemBlue 사용)
+        let existingColor = self.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? UIColor
+        let resolvedColor = linkStyle.color ?? existingColor ?? UIColor.g100
+        
+        if let font = linkStyle.font {
+            self.addAttribute(.font, value: font, range: range)
+        }
+        
+        self.addAttribute(.foregroundColor, value: resolvedColor, range: range)
+        
+        if linkStyle.underline {
+            self.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+            self.addAttribute(.underlineColor, value: resolvedColor, range: range)
+        }
+        
+        self.addAttribute(.init(TEXT_LINK), value: linkStyle.text, range: range)
+        
+        return self
+    }
+    
+    func applyMultipleLinkStyle(for linkStyleArray: [TextStyleAttributes]) -> NSMutableAttributedString {
+        
+        let source = self.string
+        
+        guard source.isEmpty == false else { return self }
+        
+        for (_, linkStyle) in linkStyleArray.enumerated() {
+            if source.contains(linkStyle.text) {
+                let range = (source as NSString).range(of: linkStyle.text)
+                // 기존에 적용된 색상 가져오기 (없으면 systemBlue 사용)
+                let existingColor = self.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? UIColor
+                let resolvedColor = linkStyle.color ?? existingColor ?? UIColor.g100
+                
+                if let font = linkStyle.font {
+                    self.addAttribute(.font, value: font, range: range)
+                }
+                
+                self.addAttribute(.foregroundColor, value: resolvedColor, range: range)
+                
+                if linkStyle.underline {
+                    self.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+                    self.addAttribute(.underlineColor, value: linkStyle.color ?? UIColor.systemBlue, range: range)
+                }
+                
+                self.addAttribute(.init(TEXT_LINK), value: linkStyle.text, range: range)
+            }
+        }
+        return self
+    }
+}
+
+public extension NSAttributedString {
+    /// 지정된 인덱스에 해당하는 커스텀 링크 텍스트 반환
+    func linkText(at index: Int, linkKey: NSAttributedString.Key = NSAttributedString.Key(TEXT_LINK)) -> String? {
+        guard index >= 0 && index < self.length else { return nil }
+        let attributes = self.attributes(at: index, effectiveRange: nil)
+        if let linkText = attributes[linkKey] as? String {
+            return linkText
+        }
+        return nil
     }
 }

--- a/Sources/DealiDesignKit/Utils/Extensions/UILabel+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/UILabel+Extension.swift
@@ -30,4 +30,56 @@ public extension UILabel {
             self.attributedText = attrString
         }
     }
+    
+    /// UILabel 내 특정 위치(point)의 링크 텍스트 추출
+    /** 사용 예시
+     label.rx.tapGesture().when(.recognized)
+         .bind(onNext: { gesture in
+             let location = gesture.location(in: label)
+             if let link = label.tappedLinkText(at: location) {
+                 print("Tapped link: \(link)")
+             }
+         })
+         .disposed(by: disposeBag)
+     */
+    func tappedLinkText(at point: CGPoint, linkKey: NSAttributedString.Key = NSAttributedString.Key(TEXT_LINK)) -> String? {
+        guard let attributedText = self.attributedText, let index = self.textIndex(at: point) else {
+            return nil
+        }
+        return attributedText.linkText(at: index, linkKey: linkKey)
+    }
+    
+    /// 입력된 포지션에 따라 라벨의 문자열의 인덱스 반환
+    /// - Parameter point: 인덱스 값을 알고 싶은 CGPoint
+    func textIndex(at point: CGPoint) -> Int? {
+        guard let attributedText = self.attributedText, !attributedText.string.isEmpty else {
+            return nil
+        }
+        
+        // 1. 텍스트 저장소
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        
+        // 2. 레이아웃 매니저
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        
+        // 3. 텍스트 컨테이너 설정
+        let textContainer = NSTextContainer(size: self.bounds.size)
+        textContainer.lineFragmentPadding = 0.0
+        textContainer.maximumNumberOfLines = self.numberOfLines
+        textContainer.lineBreakMode = self.lineBreakMode
+        layoutManager.addTextContainer(textContainer)
+        
+        // 4. 실제 텍스트가 그려지는 영역 계산
+        let glyphRange = layoutManager.glyphRange(for: textContainer)
+        let boundingRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        
+        // 5. 터치 지점이 텍스트 영역 안에 있는지 확인
+        guard boundingRect.contains(point) else {
+            return nil
+        }
+        
+        // 6. 해당 지점의 인덱스 반환
+        return layoutManager.glyphIndex(for: point, in: textContainer)
+    }
 }


### PR DESCRIPTION
## PR 마감기한
2025-05-28

## 작업 내용
- 기존 DealiBottomSheet 리스트 선택시 액션이 바텀 닫기 액션과 동일한 타이밍에 처리되는 부분에 대해서 바텀이 닫히고 난 뒤에 선택 액션이 처리되도록 수정
- AttributedString Text Link 관련 기능 추가 및 UILable 링크 액션 기능 정의

## 참고사항
작업자: @ChangHoLee 
#130 작업 다시 살려둔 PR 입니다.