### PR TITLE
TabBarView selectedIndex 변경 시 delegate 미호출 옵션 추가

### DIFF
--- a/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
+++ b/Sources/DealiDesignKit/Components/TabBar/DealiTabBarView.swift
@@ -159,13 +159,17 @@ final public class DealiTabBarView: UIView {
         }
     }
     
-    public func setSelectedIndex(index: Int, animated: Bool = true) {
+    public func setSelectedIndex(index: Int,
+                                 animated: Bool = true,
+                                 withDidSelect: Bool = true) {
         guard index >= 0 else { return }
         self.selectedIndex = index
         self.setSelectedIndexWithScroll(index: index)
         
-        /// tabbar Item button 클릭으로 이벤트 발생시 선택된 Button의 index값을 didSelectTabBarIndex를 통해 전달
-        self.delegate?.didSelectTabBar(self, selectedIndex: index, showScrollAnimation: animated)
+        if withDidSelect {
+            /// tabbar Item button 클릭으로 이벤트 발생시 선택된 Button의 index값을 didSelectTabBarIndex를 통해 전달
+            self.delegate?.didSelectTabBar(self, selectedIndex: index, showScrollAnimation: animated)
+        }
     }
     
     /// TabBar를 구성할 정보를 받아 TabBar Item Button 생성 및 정보 저장


### PR DESCRIPTION
## PR 마감기한
2025-08-29

## 작업 내용
- TabBarView에서 setSelectedIndex 호출 시 didSelectTabBar delegate 호출하지 않는 옵션 추가
디테일컷 개선 작업 중 ,
didSelect 구현부에서 리스트 fetch를 하는데, 코드로 fetch 없이 선택된 인덱스만 변경해주어야 하는 케이스가 발생해 추가합니다.