### PR TITLE
[MP-6036] Placeholder background default style light로 수정

### DIFF
--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -90,7 +90,7 @@ open class DealiPlaceholderImageView: UIImageView {
         }
     }
     
-    public var backgroundStyle: DealiPlaceholderBackgroundColor = .dark {
+    public var backgroundStyle: DealiPlaceholderBackgroundColor = .light {
         didSet {
             self.updateUI()
         }


### PR DESCRIPTION
### 배경
- 안드, 웹은 Placeholder backgroundStyle가 light를 사용하고 있어 맞추기 위해 수정

### 수정내용
- Placeholder backgroundStyle을 light로 변경
