### PR TITLE
lineHeightMultiple을 16이하에서만 사용하도록 분기

### DIFF
--- a/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
@@ -138,8 +138,14 @@ public extension NSMutableAttributedString {
         } else {
             style = NSMutableParagraphStyle()
         }
-        let multiple = maxLineHeight / font.lineHeight
-        style.lineHeightMultiple = multiple
+        
+        if #available(iOS 16.0, *) {
+            style.maximumLineHeight = maxLineHeight
+            style.minimumLineHeight = maxLineHeight
+        } else {
+            let multiple = maxLineHeight / font.lineHeight
+            style.lineHeightMultiple = multiple
+        }
 
         let baselineOffset = (maxLineHeight - font.lineHeight) / 2
 


### PR DESCRIPTION
## PR 마감기한
2025.09.15(요일)
디테일컷 개편에 반영 예정입니다.

## 작업 내용
- lineHeightMultiple 사용 시 16이하에서는 텍스트가 아래로 쳐져보이는 현상이 있어 분기처리