### PR TITLE
LineHeight 적용 테스트

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/1. Token/Typography/TypographyViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/1. Token/Typography/TypographyViewController.swift
@@ -137,6 +137,7 @@ final class TypoView: UIView {
     }
     
     private let titleLabel = UILabel()
+    private let lineHeightLabel = UILabel()
     private let textLabel = UILabel()
     
     init(fontName: String?,
@@ -149,14 +150,42 @@ final class TypoView: UIView {
         
         super.init(frame: .zero)
         
+        let verticalLine = UIView()
+        let horizontalLine = UIView()
+        
         self.addSubview(titleLabel)
         titleLabel.then {
             $0.font = self.font
             $0.textColor = .g100
-            $0.attributedText = NSMutableAttributedString(string: self.fontName ?? "").color($0.textColor).font($0.font).setLineHeight()
+            $0.attributedText = NSMutableAttributedString(string: "\(self.fontName ?? "") 333333").color($0.textColor).font($0.font).setLineHeight()
             $0.backgroundColor = .secondary03
         }.snp.makeConstraints {
             $0.top.left.right.equalToSuperview().inset(20.0)
+        }
+        
+        self.addSubview(horizontalLine)
+        horizontalLine.then {
+            $0.backgroundColor = .red
+        }.snp.makeConstraints {
+            $0.centerY.left.right.equalTo(titleLabel)
+            $0.height.equalTo(0.5)
+        }
+        
+        self.addSubview(verticalLine)
+        verticalLine.then {
+            $0.backgroundColor = .red
+        }.snp.makeConstraints {
+            $0.centerX.top.bottom.equalTo(titleLabel)
+            $0.width.equalTo(0.5)
+        }
+        
+        self.addSubview(self.lineHeightLabel)
+        self.lineHeightLabel.then {
+            $0.numberOfLines = 0
+            $0.backgroundColor = .secondary04
+        }.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4.0)
+            $0.left.right.equalToSuperview().inset(20.0)
         }
         
         self.addSubview(textLabel)
@@ -166,9 +195,16 @@ final class TypoView: UIView {
             $0.numberOfLines = 0
             $0.attributedText = NSMutableAttributedString(string: self.text).color($0.textColor).font($0.font).setLineHeight()
         }.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10.0)
+            $0.top.equalTo(lineHeightLabel.snp.bottom).offset(10.0)
             $0.bottom.left.right.equalToSuperview().inset(20.0)
         }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.lineHeightLabel.attributedText = NSMutableAttributedString(string: "dealiLineHeight: \(self.font.dealiLineHeight) / labelHeight: \(self.titleLabel.frame.height)")
+            .color(.g100).font(.b2sb14).setLineHeight()
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
@@ -115,45 +115,38 @@ public extension NSMutableAttributedString {
     }
     
     private func setLineHeightWithBaselineOffset() -> NSMutableAttributedString {
-        let source = self.string
-        guard source.isEmpty == false else { return self }
+        guard self.length > 0 else { return self }
 
-        var maxLineHeight: CGFloat = 0.0
-        var firstFont: UIFont?
+        // 1) max line height 수집 (dealiLineHeight는 프로젝트 정의)
+        var maxLineHeight: CGFloat = 0
+        self.enumerateAttribute(.font, in: NSRange(location: 0, length: self.length)) { attribute, _, _ in
+            if let font = attribute as? UIFont { maxLineHeight = max(maxLineHeight, font.dealiLineHeight) }
+        }
+        guard maxLineHeight > 0 else { return self }
 
-        self.enumerateAttribute(.font, in: NSRange(location: 0, length: self.length), options: []) { value, _, _ in
-            if let font = value as? UIFont {
-                maxLineHeight = max(maxLineHeight, font.dealiLineHeight)
-                if firstFont == nil { firstFont = font }
+        // 2) paragraphStyle: 모든 iOS에서 min/max 고정
+        let all = NSRange(location: 0, length: self.length)
+        let style: NSMutableParagraphStyle = (self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle)?
+            .mutableCopy() as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+        // 라인 고정은 그대로
+        style.minimumLineHeight = maxLineHeight
+        style.maximumLineHeight = maxLineHeight
+        self.addAttribute(.paragraphStyle, value: style, range: all)
+
+        // run별 baseline 보정(심플 버전)
+        let k: CGFloat = 0.9   // 보정 강도 (0.0~1.0), 작을수록 약하게
+        let bias: CGFloat = -0.5 // 전체적으로 "아래로" 내리는 바이어스(필요 없으면 0)
+
+        self.enumerateAttributes(in: all, options: []) { attrs, range, _ in
+            guard let f = attrs[.font] as? UIFont else { return }
+            var local = ((maxLineHeight - f.lineHeight) * 0.5) * k + bias
+            // 픽셀 스냅(선택)
+            let scale = UIScreen.main.scale
+            local = (local * scale).rounded() / scale
+            if abs(local) > 0.01 {
+                self.addAttribute(.baselineOffset, value: local, range: range)
             }
         }
-
-        guard let font = firstFont else { return self }
-
-        let range = (source as NSString).range(of: source)
-        // 기존 paragraphStyle을 먼저 가져오기
-        let style: NSMutableParagraphStyle
-        if let existingStyle = self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle {
-            style = existingStyle.mutableCopy() as! NSMutableParagraphStyle
-        } else {
-            style = NSMutableParagraphStyle()
-        }
-        
-        if #available(iOS 16.0, *) {
-            style.maximumLineHeight = maxLineHeight
-            style.minimumLineHeight = maxLineHeight
-        } else {
-            let multiple = maxLineHeight / font.lineHeight
-            style.lineHeightMultiple = multiple
-        }
-
-        let baselineOffset = (maxLineHeight - font.lineHeight) / 2
-
-        self.addAttributes([
-            .paragraphStyle: style,
-            .baselineOffset: baselineOffset
-        ], range: range)
-
         return self
     }
     


### PR DESCRIPTION
## PR 마감기한
2025.09.12(금요일)

## 작업 내용
- setLineHeight() 적용시 iOS 버전마다, UILabel의 높이가 다르게 잡히던 점을 수정
- setLineHeight() 적용시 text가 세로 기준 가운데에 위치하도록 조정

<img width="1179" height="2556" alt="simulator_screenshot_D6F5D6AD-3020-4DB1-9A9E-0E54E1650723" src="https://github.com/user-attachments/assets/1db2c4a2-2740-4b0f-ba30-55a34020ccfa" />
