### PR TITLE
[MP-6152] ImagePlaceholder, resizeURLImageView, systemImageView 생성

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DealiDesignKit",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v16)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
+++ b/Sources/DealiDesignKit/Components/PlaceholderImageView/DealiPlaceholderImageView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 import SnapKit
 
 public enum DealiPlaceholderImageStyle {
@@ -77,6 +78,29 @@ public enum DealiPlaceholderViewShape: RadiusProvider {
             return height / 2.0
             
         }
+    }
+    
+    func shape() -> some Shape {
+        switch self {
+        case .rectangle(let corners):
+            return AnyShape(RoundedCorner(radius: 6.0, corners: corners))
+        case .circle:
+            return AnyShape(Circle())
+        }
+    }
+}
+
+private struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
+        return Path(path.cgPath)
     }
 }
 

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiImagePlaceholder.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiImagePlaceholder.swift
@@ -1,0 +1,154 @@
+//
+//  DealiImagePlaceholder.swift
+//  DealiDesignKit
+//
+//  Created by 윤조현 on 10/30/25.
+//
+
+import SwiftUI
+
+/**
+ 설명: 이미지 placeholder 
+ */
+public struct DealiImagePlaceholder: View {
+    public let imageStyle: DealiPlaceholderImageStyle
+    public let backgroundStyle: DealiPlaceholderBackgroundColor
+    public let shape: DealiPlaceholderViewShape
+
+    func iconView() -> Image {
+        switch imageStyle {
+        case .store:
+            DealiIcon.ic_home_filled.swiftUIImage
+        default:
+            DealiIcon.ic_empty40.swiftUIImage
+        }
+    }
+
+    public init(
+        imageStyle: DealiPlaceholderImageStyle = .goods,
+        backgroundStyle: DealiPlaceholderBackgroundColor = .dark,
+        shape: DealiPlaceholderViewShape = .rectangle(.allCorners)
+    ) {
+        self.imageStyle = imageStyle
+        self.backgroundStyle = backgroundStyle
+        self.shape = shape
+    }
+
+    public var body: some View {
+        GeometryReader { geometry in
+            let size = geometry.size
+            let placeholderSize = calculateIconSize(for: size)
+            ZStack {
+                Color(backgroundStyle.backgroundColor)
+                self.iconView()
+                    .resizable()
+                    .renderingMode(.template)
+                    .foregroundColor(Color(backgroundStyle.imageColor))
+                    .scaledToFit()
+                    .frame(width: placeholderSize.width, height: placeholderSize.height)
+            }
+            .clipShape(shape.shape())
+            .overlay(
+                shape.shape()
+                    .stroke(
+                        Color(shape.borderColor),
+                        lineWidth: shape.borderWidth
+                    )
+            )
+        }
+    }
+
+    private func calculateIconSize(for parentSize: CGSize) -> CGSize {
+        guard parentSize.width > 0, parentSize.height > 0 else { return .zero }
+        
+        let parentWidth = parentSize.width
+        var placeholderWidth: CGFloat = 0.0
+        var placeholderHeight: CGFloat = 0.0
+        
+        switch self.imageStyle {
+        case .custom(let image) where image != nil:
+            return parentSize
+            
+        default:
+            let isOneToOne = abs(parentSize.width / parentSize.height - 1.0) < 0.01
+            
+            if isOneToOne {
+                if parentWidth <= 70.0 {
+                    placeholderWidth = parentWidth / 2.0
+                } else {
+                    placeholderWidth = parentWidth / 2.5
+                }
+                placeholderHeight = placeholderWidth
+            } else {
+                placeholderWidth = parentWidth / 2.5
+                
+                switch self.imageStyle {
+                case .goods:
+                    placeholderHeight = placeholderWidth * 4 / 3
+                default:
+                    placeholderHeight = placeholderWidth
+                }
+            }
+        }
+        
+        return CGSize(width: placeholderWidth, height: placeholderHeight)
+    }
+}
+
+private struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
+        return Path(path.cgPath)
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(alignment: .center) {
+            Text("210*280")
+            DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .dark, shape: .rectangle(.allCorners))
+                .frame(width: 210, height: 280)
+
+            Text("165*220")
+            HStack {
+                DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .dark, shape: .rectangle(.allCorners))
+                    .frame(width: 165, height: 220)
+                DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .light, shape: .rectangle(.allCorners))
+                    .frame(width: 165, height: 220)
+            
+            }
+            
+            Text("108*144")
+            DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .dark, shape: .rectangle(.allCorners))
+                .frame(width: 108, height: 144)
+            
+            Text("108*108")
+            DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .dark, shape: .rectangle(.allCorners))
+                .frame(width: 108, height: 108)
+          
+            DealiImagePlaceholder(imageStyle: .store, backgroundStyle: .dark, shape: .circle)
+                .frame(width: 90, height: 90)
+        }
+    }
+}
+
+
+#Preview("70미만 사이즈") {
+    ScrollView {
+        VStack(alignment: .center) {
+            Text("68*68")
+            DealiImagePlaceholder(imageStyle: .goods, backgroundStyle: .dark, shape: .rectangle(.allCorners))
+                .frame(width: 68, height: 68)
+
+            DealiImagePlaceholder(imageStyle: .store, backgroundStyle: .light, shape: .circle)
+                .frame(width: 60, height: 60)
+        }
+    }
+}

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiImagePlaceholder.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiImagePlaceholder.swift
@@ -26,7 +26,7 @@ public struct DealiImagePlaceholder: View {
 
     public init(
         imageStyle: DealiPlaceholderImageStyle = .goods,
-        backgroundStyle: DealiPlaceholderBackgroundColor = .dark,
+        backgroundStyle: DealiPlaceholderBackgroundColor = .light,
         shape: DealiPlaceholderViewShape = .rectangle(.allCorners)
     ) {
         self.imageStyle = imageStyle

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiResizableRemoteImageView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiResizableRemoteImageView.swift
@@ -1,0 +1,74 @@
+//
+//  DealiResizableRemoteImageView.swift
+//  DealiDesignKit
+//
+//  Created by 윤조현 on 10/30/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+/**
+ 설명: 이미지 사이즈에 맞게 리사이징한 url을 받아와 이미지를 보여주는 뷰
+ */
+public struct DealiResizableRemoteImageView<Placeholder: View>: View {
+    let urlString: String?
+    var contentMode: SwiftUI.ContentMode = .fill
+    var resizer: (((String?, CGSize)) -> URL?)?
+    var placeholder: Placeholder
+
+    public init(
+        urlString: String?,
+        contentMode: SwiftUI.ContentMode = .fill,
+        resizer: (((String?, CGSize)) -> URL?)?,
+        @ViewBuilder placeholder: () -> Placeholder = { DealiImagePlaceholder() }
+    ) {
+        self.urlString = urlString
+        self.contentMode = contentMode
+        self.resizer = resizer
+        self.placeholder = placeholder()
+    }
+    
+    public var body: some View {
+        GeometryReader { geometry in
+            let targetSize = geometry.size
+            
+            let finalUrl = self.resizer?((self.urlString, targetSize))
+            
+            let width = targetSize.width * UIScreen.main.scale
+            let height = targetSize.height * UIScreen.main.scale
+            let processor = DownsamplingImageProcessor(size: CGSize(width: width, height: height))
+            
+            KFImage(finalUrl)
+                .placeholder { self.placeholder }
+                .setProcessor(processor)
+                .cacheOriginalImage(false)
+                .cancelOnDisappear(true)
+                .resizable()
+                .aspectRatio(contentMode: self.contentMode)
+                .frame(width: targetSize.width, height: targetSize.height)
+                .clipped()
+        }
+    }
+}
+
+// MARK: - Preview
+struct DealiResizableRemoteImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            VStack {
+                DealiResizableRemoteImageView(urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDh8UzRNS0xBc0JCNzR8fGVufDB8fHx8fA%3D%3D", resizer: { urlString, _ in
+                    guard let urlString = urlString else { return nil }
+                    return URL(string: urlString)
+                })
+                    .frame(width: 200, height: 150)
+                    .padding()
+                
+                DealiResizableRemoteImageView(urlString: nil, resizer: nil)
+                    .frame(width: 200, height: 150)
+                    .padding()
+            }
+            .previewLayout(.sizeThatFits)
+        }
+    }
+}

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
@@ -13,7 +13,7 @@ public struct DealiSystemImageView: View {
     let urlString: String?
     let systemStyle: DealiImageSystemStyle
     var resizer: (((String?, CGSize)) -> URL?)?
-    `
+    
     public init(
         urlString: String? = nil,
         systemStyle: DealiImageSystemStyle,
@@ -21,7 +21,7 @@ public struct DealiSystemImageView: View {
             self.urlString = urlString
             self.systemStyle = systemStyle
             self.resizer = resizer
-        }`
+        }
 
     // systemStyle을 기반으로 placeholder를 내부에서 구성
     var placeholder: some View {

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
@@ -12,16 +12,20 @@ import SwiftUI
 public struct DealiSystemImageView: View {
     let urlString: String?
     let systemStyle: DealiImageSystemStyle
-    var resizer: (((String?, CGSize)) -> URL?)?
     
-    public init(
-        urlString: String? = nil,
-        systemStyle: DealiImageSystemStyle,
-        resizer: (((String?, CGSize)) -> URL?)?) {
-            self.urlString = urlString
-            self.systemStyle = systemStyle
-            self.resizer = resizer
-        }
+    let isDimmed: Bool
+    var resizer: (((String?, CGSize)) -> URL?)?
+
+    public init(urlString: String? = nil,
+                systemStyle: DealiImageSystemStyle,
+                isDimmed: Bool = false,
+                resizer: (((String?, CGSize)) -> URL?)?
+    ) {
+        self.urlString = urlString
+        self.systemStyle = systemStyle
+        self.isDimmed = isDimmed
+        self.resizer = resizer
+    }
 
     // systemStyle을 기반으로 placeholder를 내부에서 구성
     var placeholder: some View {
@@ -33,17 +37,23 @@ public struct DealiSystemImageView: View {
     }
     
     public var body: some View {
+        let shape = self.systemStyle.shape.shape()
+        
         DealiResizableRemoteImageView(
             urlString: self.urlString,
             resizer: self.resizer
         ) {
             self.placeholder
         }
-        .clipShape(self.systemStyle.shape.shape())
-        .overlay(
-            self.systemStyle.shape.shape()
-                .stroke(self.systemStyle.strokeColor, lineWidth: 1)
-        )
+        .clipShape(shape)
+        .overlay {
+            shape.stroke(self.systemStyle.strokeColor, lineWidth: 1)
+        }
+        .overlay {
+            if isDimmed {
+                shape.fill(Color.b40)
+            }
+        }
     }
 }
 

--- a/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/ImageView/DealiSystemImageView.swift
@@ -1,0 +1,127 @@
+//
+//  SwiftUIView.swift
+//  DealiDesignKit
+//
+//  Created by 윤조현 on 10/30/25.
+//
+
+import SwiftUI
+/**
+ 설명: systemStyle을 받아 리사이징 및 placeholder를 그리는 시스템 컴포넌트
+ */
+public struct DealiSystemImageView: View {
+    let urlString: String?
+    let systemStyle: DealiImageSystemStyle
+    var resizer: (((String?, CGSize)) -> URL?)?
+    `
+    public init(
+        urlString: String? = nil,
+        systemStyle: DealiImageSystemStyle,
+        resizer: (((String?, CGSize)) -> URL?)?) {
+            self.urlString = urlString
+            self.systemStyle = systemStyle
+            self.resizer = resizer
+        }`
+
+    // systemStyle을 기반으로 placeholder를 내부에서 구성
+    var placeholder: some View {
+        DealiImagePlaceholder(
+            imageStyle: self.systemStyle.placeholderImageStyle,
+            backgroundStyle: self.systemStyle.placeholderBackgroundStyle,
+            shape: self.systemStyle.shape
+        )
+    }
+    
+    public var body: some View {
+        DealiResizableRemoteImageView(
+            urlString: self.urlString,
+            resizer: self.resizer
+        ) {
+            self.placeholder
+        }
+        .clipShape(self.systemStyle.shape.shape())
+        .overlay(
+            self.systemStyle.shape.shape()
+                .stroke(self.systemStyle.strokeColor, lineWidth: 1)
+        )
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        Text("Store Profile Style")
+        DealiSystemImageView(
+            urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDh8UzRNS0xBc0JCNzR8fGVufDB8fHx8fA%3D%3D",
+            systemStyle: .storeProfile,
+            resizer: { urlString, _ in
+                guard let urlString = urlString else { return nil }
+                return URL(string: urlString)
+            }
+        )
+        .frame(width: 100, height: 100)
+        
+        DealiSystemImageView(
+            urlString: nil,
+            systemStyle: .storeProfile,
+            resizer: nil
+        )
+        .frame(width: 100, height: 100)
+        
+        Text("Product Thumbnail Style")
+        DealiSystemImageView(
+            urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHx0b3BpYy1mZWVkfDh8UzRNS0xBc0JCNzR8fGVufDB8fHx8fA%3D%3D",
+            systemStyle: .productThumbnail,
+            resizer: { urlString, _ in
+                guard let urlString = urlString else { return nil }
+                return URL(string: urlString)
+            }
+        )
+        .frame(width: 120, height: 160)
+        
+        DealiSystemImageView(
+            urlString: nil,
+            systemStyle: .productThumbnail,
+            resizer: nil
+        )
+        .frame(width: 120, height: 160)
+    }
+}
+
+public enum DealiImageSystemStyle {
+    case storeProfile
+    case productThumbnail
+
+    var placeholderImageStyle: DealiPlaceholderImageStyle {
+        switch self {
+        case .storeProfile:
+            return .store
+        case .productThumbnail:
+            return .goods
+        }
+    }
+    
+    /// 각 스타일에 맞는 플레이스홀더 배경 종류
+    var placeholderBackgroundStyle: DealiPlaceholderBackgroundColor {
+        switch self {
+        case .storeProfile:
+            return .dark
+        case .productThumbnail:
+            return .dark
+        }
+    }
+
+    /// 각 스타일에 맞는 모양
+    var shape: DealiPlaceholderViewShape {
+        switch self {
+        case .storeProfile:
+            return .circle
+        case .productThumbnail:
+            return .rectangle(.allCorners)
+        }
+    }
+    
+    // 테두리 색상
+    var strokeColor: Color {
+        return Color(shape.borderColor)
+    }
+}

--- a/Sources/DealiDesignKit/Utils/Extensions/SwiftUI+Extension/Image+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/SwiftUI+Extension/Image+Extension.swift
@@ -15,40 +15,6 @@ public extension Image {
     }
 }
 
-public struct KFImageView: View {
-    let url: URL?
-    let size: CGSize?
-    let contentMode: SwiftUI.ContentMode
-    let completion: ((UIImage?) -> Void)?
-
-    public init(url: URL?,
-                size: CGSize? = nil,
-                contentMode: SwiftUI.ContentMode = .fit,
-                completion: ((UIImage?) -> Void)? = nil) {
-        self.url = url
-        self.size = size
-        self.contentMode = contentMode
-        self.completion = completion
-    }
-
-    public var body: some View {
-        KFImage(url)
-            .placeholder {
-                Color.gray.opacity(0.1)
-            }
-            .setProcessor()
-            .onSuccess { result in
-                completion?(result.image)
-            }
-            .onFailure { _ in
-                completion?(nil)
-            }
-            .resizable()
-            .aspectRatio(contentMode: contentMode)
-            .frame(width: size?.width, height: size?.height)
-    }
-}
-
 private extension KFImage {
     func setProcessor(_ size: CGSize? = nil) -> KFImage {
         guard let size else { return self }


### PR DESCRIPTION
## PR 마감기한
2025.11.07 (금)

## 작업 내용
- Image가 비어있을 때 나오는 시스템 플레이스홀더 뷰 개발
- url 받았을 때 이미지 사이즈에 맞춰 리사이징한 url 리턴해서 보여주는 뷰 개발
- 두 개의 저수준 컴포넌트를 조합하여, 상품이나 매장 등에서 공통으로 사용할 수 있는 SystemImageView를 생성

## Merge 전 필요한 작업
- N/A

## 머지 후 프로젝트에서
사용의 편리함을 위해 resizer 를 디폴트로 주입하는 확장함수 추가하여 사용
```swift

extension DealiResizableRemoteImageView {
    init(urlString: String?,
         contentMode: SwiftUI.ContentMode = .fill,
         @ViewBuilder placeholder: () -> Placeholder = { DealiImagePlaceholder() }) {
        
        self.init(
            urlString: urlString,
            contentMode: contentMode,
            resizer: { (urlString, size) in
                guard let urlString = urlString, !urlString.isEmpty else { return nil }
                
                let width = size.width * UIScreen.main.scale
                let height = size.height * UIScreen.main.scale
                return Util.getResizedImageURL(urlString: urlString, width: width, height: height)
            },
            placeholder: placeholder
        )
    }
}

extension DealiSystemImageView {
    
    init(urlString: String? = nil,
         systemStyle: DealiImageSystemStyle) {
        self.init(
            urlString: urlString,
            systemStyle: systemStyle) { (urlString, size) in
                guard let urlString = urlString, !urlString.isEmpty else { return nil }
                
                let width = size.width * UIScreen.main.scale
                let height = size.height * UIScreen.main.scale
                return Util.getResizedImageURL(urlString: urlString, width: width, height: height)
            }
    }
}

```

## 주의해서 봐야 할 부분
- 이렇게 하는 것이 좋을까요?
- 문제 없는지 테스트 해주세요
