### PR TITLE
NSAttStr bullet 코드 개선

### DIFF
--- a/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/NSAttributedString+Extension.swift
@@ -187,22 +187,35 @@ public extension NSMutableAttributedString {
 
     func bullet(_ bullet: String) -> NSMutableAttributedString {
         let source = self.string
+        guard source.isEmpty == false, bullet.isEmpty == false else { return self }
         
-        guard source.isEmpty == false else { return self }
-        
-        let range = (source as NSString).range(of: source)
-        var style: NSMutableParagraphStyle?
-        if let paragraphStyle = self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle {
-            style = paragraphStyle
-            style?.headIndent = (bullet as NSString).size().width
-        } else {
-            style = NSMutableParagraphStyle()
-            style?.headIndent = (bullet as NSString).size().width
+        // 불릿 중복 검사
+        if source.hasPrefix(bullet) == false {
+            // 불릿에 폰트와 동일한 스타일 적용
+            let attrs: [NSAttributedString.Key: Any]
+            if self.length > 0 {
+                attrs = self.attributes(at: 0, effectiveRange: nil)
+            } else {
+                attrs = [:]
+            }
+            let bulletAttr = NSAttributedString(string: bullet, attributes: attrs)
+            self.insert(bulletAttr, at: 0)
         }
         
-        if let style = style {
-            self.addAttribute(.paragraphStyle, value: style, range: range)
-        }
+        let fullRange = NSRange(location: 0, length: self.length)
+        let font = (self.attribute(.font, at: 0, effectiveRange: nil) as? UIFont) ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        let bulletWidth = (bullet as NSString).size(withAttributes: [.font: font]).width
+        
+        let style: NSMutableParagraphStyle = (
+            (self.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle)?
+                .mutableCopy() as? NSMutableParagraphStyle
+        ) ?? NSMutableParagraphStyle()
+        
+        style.firstLineHeadIndent = 0
+        style.headIndent = bulletWidth
+        
+        self.addAttribute(.paragraphStyle, value: style, range: fullRange)
+        
         return self
     }
     


### PR DESCRIPTION
- bullet 사용 시 string에 동일한 문구를 추가해주는 코드를 개선
- as-is
<img width="646" height="276" alt="image" src="https://github.com/user-attachments/assets/0750e8b3-c03b-4955-9b8a-445aebf34a6f" />

- to-be
<img width="560" height="260" alt="image" src="https://github.com/user-attachments/assets/68b4788d-4be9-47b1-816b-887164c389ab" />
