### PR TITLE
SwiftUI 버튼 수정

### DIFF
--- a/Sources/DealiDesignKit/SwiftUIComponents/Buttons/ButtonView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/Buttons/ButtonView.swift
@@ -92,7 +92,6 @@ public struct ButtonView: View {
     public var body: some View {
         ZStack {
             buttonContainerView
-                .padding(.vertical, viewModel.style.heightPadding)
             
             if viewModel.isLoading {
                 IndicatorImageView
@@ -208,12 +207,6 @@ struct ButtonViewStyle: ButtonStyle {
                 : self.viewModel.style.color.attribute.disabled.text
         
         ZStack {
-            if !viewModel.isLoading {
-                if configuration.isPressed && viewModel.isEnabled {
-                    rippleView
-                }
-            }
-            
             HStack(spacing: viewModel.style.widthPadding?.internalSpacing) {
                 if let leftImageSet = viewModel.leftImage, let leftImage = self.processedUIImage(imageSet: leftImageSet) {
                     if leftImageSet.needOriginColor == true {
@@ -229,7 +222,7 @@ struct ButtonViewStyle: ButtonStyle {
                     .multilineTextAlignment(viewModel.titleAlignment)
                     .font(viewModel.style.font)
                     .foregroundColor(viewModel.isLoading ? .clear : viewModel.style.foregroundColor)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity)
                 
                 if let rightImageSet = viewModel.rightImage, let rightImage = self.processedUIImage(imageSet: rightImageSet) {
                     if rightImageSet.needOriginColor == true {
@@ -253,6 +246,17 @@ struct ButtonViewStyle: ButtonStyle {
                      : (viewModel.style.widthPadding?.normal ?? 0.0)
             )
             .padding(.vertical, viewModel.style.heightPadding)
+            .background(
+                Group {
+                    if configuration.isPressed,
+                       viewModel.isEnabled,
+                       !viewModel.isLoading {
+                        rippleView
+                    } else {
+                        Color.clear
+                    }
+                }
+            )
         }
         .contentShape(Rectangle()) // 클릭영역을 버튼 전체로 세팅
     }


### PR DESCRIPTION
버튼 높이가 infinity라서 텍스트가 아닌 부모뷰의 높이를 모두 차지하는 문제 해결
(버튼을 감싸는 stackview와 높이가 같아지거나, AlertView에서 버튼이 무한히 늘어남)
- 버튼 높이가 텍스트에 맞게 확장될 수 있도록 수정 (maxHeight: .infinity 제거)
- 중복 padding 코드 제거
- rippleView 를 background로 위치 수정 (리플도 무한히 늘어나지 않도록 위치 수정)
