### PR TITLE
[MP-6316] 버튼 텍스트 priority 수정

### DIFF
--- a/Sources/DealiDesignKit/Components/Control/ClickableUnitButton.swift
+++ b/Sources/DealiDesignKit/Components/Control/ClickableUnitButton.swift
@@ -220,6 +220,7 @@ public class ClickableUnitButton: SystemButton {
             $0.lineBreakMode = .byTruncatingTail
             $0.textAlignment = .center
             $0.lineBreakMode = .byWordWrapping
+            $0.setContentCompressionResistancePriority(.required, for: .vertical)
         }.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
         }


### PR DESCRIPTION
## PR 마감기한
지금

## 작업 내용
- 버튼 label의 vertical compressionResistancePriority 지정
- 버튼 자체에 vertical compression을 주면 텍스트가 높이 유지 안되는 현상 수정
<img width="1026" height="182" alt="image" src="https://github.com/user-attachments/assets/4d3ad28e-9f54-4e6c-b268-57fa064cf5b1" />
