### PR TITLE
바텀시트 title close 버튼 핸들러에 cancelAction 추가

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
@@ -196,7 +196,9 @@ extension BottomSheetPopupTestViewController {
             selectAction: { indecies in
                 debugPrint("눌림:\(indecies)")
                 
-            }, cancelAction: nil,
+            }, cancelAction: {
+                debugPrint("cancel click")
+            },
             confirmAction: nil
         )
     }

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -260,9 +260,13 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
     }
     
     var shouldDismissWhenSelect: Bool = false
+    /// title close 버튼 클릭시 cancel Action 호출 유무
+    var cancelActionOnCloseButton: Bool = false
     var cancelAction: (() -> Void)? {
         didSet {
-            self.closeActionHandler = self.cancelAction
+            if self.cancelActionOnCloseButton {
+                self.closeActionHandler = self.cancelAction
+            }
         }
     }
     var confirmAction: (() -> Void)?

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -260,7 +260,11 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
     }
     
     var shouldDismissWhenSelect: Bool = false
-    var cancelAction: (() -> Void)?
+    var cancelAction: (() -> Void)? {
+        didSet {
+            self.closeActionHandler = self.cancelAction
+        }
+    }
     var confirmAction: (() -> Void)?
     var selectAction: (([Int]) -> Void)?
     


### PR DESCRIPTION
## PR 마감기한
- 2026.01.22 (교환반품에 포함 예정)

## 작업 내용
- BottomSheet Close Button 에 cancel Action Handler 호출되도록 추가
closeActionHandler를 미사용중.. close할때도 cancel 액션이 필요해서 추가했습니다. 