### PR TITLE
[MP-6398] DealiBottomSheet margin 이슈 및 close버튼만 노출될경우 UI이슈 수정

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
@@ -189,7 +189,7 @@ extension BottomSheetPopupTestViewController {
         ]
                                                         
         DealiBottomSheet.showSingleSelectionType(
-            titleType: .titleCloseButton(title: "단일선택 바텀시트"),
+            titleType: .closeButton,
             option: optionData,
             shouldDismissWhenSelect: true,
             popupPresentingViewController: self,

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheetBaseViewController.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheetBaseViewController.swift
@@ -132,7 +132,7 @@ open class DealiBottomSheetBaseViewController: UIViewController {
         }.snp.makeConstraints {
             $0.top.equalToSuperview().offset(self.titleType == .hidden ? 16.0 : 14.0)
             $0.left.right.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(safeAreaBottomMargin)
         }
         
         self.contentStackView.addArrangedSubview(self.containerView)
@@ -212,31 +212,25 @@ open class DealiBottomSheetBaseViewController: UIViewController {
             $0.top.left.right.bottom.equalToSuperview()
         }
         
+        titleContainerStackView.addArrangedSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+        }
+        
+        titleContainerStackView.addArrangedSubview(self.closeButton)
+        self.closeButton.snp.makeConstraints {
+            $0.size.equalTo(CGSize(width: 24.0, height: 24.0))
+        }
+        
         switch self.titleType {
         case .title(let title):
-            titleContainerStackView.addArrangedSubview(self.titleLabel)
             self.titleLabel.text = title
-            self.titleLabel.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
-            }
+            self.closeButton.isHidden = true
         case .closeButton:
-            titleContainerStackView.addArrangedSubview(self.closeButton)
-            self.closeButton.snp.makeConstraints {
-                $0.centerY.equalToSuperview()
-                $0.size.equalTo(CGSize(width: 24.0, height: 24.0))
-            }
+            self.closeButton.isHidden = false
         case .titleCloseButton(let title):
-            titleContainerStackView.addArrangedSubview(self.titleLabel)
             self.titleLabel.text = title
-            self.titleLabel.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
-            }
-            
-            titleContainerStackView.addArrangedSubview(self.closeButton)
-            self.closeButton.snp.makeConstraints {
-                $0.centerY.equalToSuperview()
-                $0.size.equalTo(CGSize(width: 24.0, height: 24.0))
-            }
+            self.closeButton.isHidden = false
         default:
             break
         }


### PR DESCRIPTION
DealiBottomSheet Bottom margin 이슈 수정
DealiBottomSheet title영역 close버튼만 노출되는 경우 버튼이 중앙에 위치하는 이슈 수정