### PR TITLE
[MP-6531] chipOutlineSquareImage 컴포넌트 추가

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/2. Atom/ImageChip/ImageChipViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/2. Atom/ImageChip/ImageChipViewController.swift
@@ -25,6 +25,14 @@ final class ImageChipViewController: UIViewController {
     private let smallSelectedImageChip = DealiControl.imgChipSmall01()
     private let smallDisabledImageChip = DealiControl.imgChipSmall01()
     
+    private let outlineSquareImageChip = DealiControl.chipOutlineSquareImageLarge01()
+    private let outlineSquareImageDisabledChip = DealiControl.chipOutlineSquareImageLarge01()
+    private let outlineSquareImageWithXChip = DealiControl.chipOutlineSquareImageLarge01()
+    private let outlineSquareImageMediumChip = DealiControl.chipOutlineSquareImageMedium01()
+    private let outlineSquareImageMediumDisabledChip = DealiControl.chipOutlineSquareImageMedium01()
+    private let outlineSquareImageTruncateChip = DealiControl.chipOutlineSquareImageLarge01()
+    private let outlineSquareImageMediumTruncateChip = DealiControl.chipOutlineSquareImageMedium01()
+    
     private let disposeBag = DisposeBag()
     private let detachBag = AnyDetachBag()
     private let isSwiftUI: Bool
@@ -70,6 +78,20 @@ final class ImageChipViewController: UIViewController {
             .bind(with: self) { owner, _ in
                 owner.smallImageChip.isSelected.toggle()
                 
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.outlineSquareImageTruncateChip.rx.tap
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                owner.outlineSquareImageTruncateChip.isSelected.toggle()
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.outlineSquareImageMediumTruncateChip.rx.tap
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                owner.outlineSquareImageMediumTruncateChip.isSelected.toggle()
             }
             .disposed(by: self.disposeBag)
     }
@@ -126,6 +148,63 @@ private extension ImageChipViewController {
         stackView.addArrangedSubview(smallDisabledImageChip)
         smallDisabledImageChip.status = .disabled
         
+        let outlineSquareTitleLabel = UILabel()
+        outlineSquareTitleLabel.text = "chipOutlineSquareImageLarge01"
+        outlineSquareTitleLabel.font = .b2sb14
+        outlineSquareTitleLabel.textColor = .g80
+        stackView.addArrangedSubview(outlineSquareTitleLabel)
+        
+        stackView.addArrangedSubview(outlineSquareImageChip)
+        outlineSquareImageChip.title = "Outline Square"
+        outlineSquareImageChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        
+        stackView.addArrangedSubview(outlineSquareImageDisabledChip)
+        outlineSquareImageDisabledChip.title = "Disabled"
+        outlineSquareImageDisabledChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        outlineSquareImageDisabledChip.status = .disabled
+        
+        stackView.addArrangedSubview(outlineSquareImageWithXChip)
+        outlineSquareImageWithXChip.title = "제거 가능(X 탭 시 제거)"
+        outlineSquareImageWithXChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        outlineSquareImageWithXChip.rightImage = UIImage.dealiIcon(named: "ic_x_s")
+        outlineSquareImageWithXChip.onRightIconTap = { [weak outlineSquareImageWithXChip] in
+            guard let chip = outlineSquareImageWithXChip, let stackView = chip.superview as? UIStackView else { return }
+            stackView.removeArrangedSubview(chip)
+            chip.removeFromSuperview()
+        }
+        
+        let outlineSquareMediumTitleLabel = UILabel()
+        outlineSquareMediumTitleLabel.text = "chipOutlineSquareImageMedium01"
+        outlineSquareMediumTitleLabel.font = .b2sb14
+        outlineSquareMediumTitleLabel.textColor = .g80
+        stackView.addArrangedSubview(outlineSquareMediumTitleLabel)
+        
+        stackView.addArrangedSubview(outlineSquareImageMediumChip)
+        outlineSquareImageMediumChip.title = "Outline Square Medium"
+        outlineSquareImageMediumChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        
+        stackView.addArrangedSubview(outlineSquareImageMediumDisabledChip)
+        outlineSquareImageMediumDisabledChip.title = "Disabled"
+        outlineSquareImageMediumDisabledChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        outlineSquareImageMediumDisabledChip.status = .disabled
+        
+        let truncateTitleLabel = UILabel()
+        truncateTitleLabel.text = "width 강제 지정 시 말줄임"
+        truncateTitleLabel.font = .b2sb14
+        truncateTitleLabel.textColor = .g80
+        stackView.addArrangedSubview(truncateTitleLabel)
+        
+        let longText = "이것은 아주 긴 텍스트가 들어갔을 때 말줄임 테스트입니다"
+        stackView.addArrangedSubview(outlineSquareImageTruncateChip)
+        outlineSquareImageTruncateChip.title = longText
+        outlineSquareImageTruncateChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        outlineSquareImageTruncateChip.snp.makeConstraints { $0.width.equalTo(200) }
+        
+        stackView.addArrangedSubview(outlineSquareImageMediumTruncateChip)
+        outlineSquareImageMediumTruncateChip.title = longText
+        outlineSquareImageMediumTruncateChip.imageURL = URL(string: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60")
+        outlineSquareImageMediumTruncateChip.snp.makeConstraints { $0.width.equalTo(160) }
+        
         stackView.addArrangedSubview(UIView())
         return stackView
     }
@@ -169,6 +248,49 @@ private extension ImageChipViewController {
             .detached(by: self.detachBag)
         
         stackView.addArrangedSubview(result2.view)
+        
+        let outlineSquareViewModel = DealiImageChipViewModel(
+            urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60",
+            text: "Outline Square"
+        )
+        let outlineSquareResult = DealiImageChip(
+            viewModel: outlineSquareViewModel,
+            action: { debugPrint("chipOutlineSquareImageLarge01 탭") },
+            content: { EmptyView() },
+            preset: .imgOutlineSquareLarge01
+        )
+        .toUIView(embeddedIn: self)
+        .detached(by: self.detachBag)
+        stackView.addArrangedSubview(outlineSquareResult.view)
+        
+        let outlineSquareMediumViewModel = DealiImageChipViewModel(
+            urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60",
+            text: "Outline Square Medium"
+        )
+        let outlineSquareMediumResult = DealiImageChip(
+            viewModel: outlineSquareMediumViewModel,
+            action: { debugPrint("chipOutlineSquareImageMedium01 탭") },
+            content: { EmptyView() },
+            preset: .imgOutlineSquareMedium01
+        )
+        .toUIView(embeddedIn: self)
+        .detached(by: self.detachBag)
+        stackView.addArrangedSubview(outlineSquareMediumResult.view)
+        
+        let outlineSquareWithXViewModel = DealiImageChipViewModel(
+            urlString: "https://images.unsplash.com/photo-1731021347639-8aac941f5e29?w=500&auto=format&fit=crop&q=60",
+            text: "제거 가능",
+            iconName: "ic_x_s"
+        )
+        let outlineSquareWithXResult = DealiImageChip(
+            viewModel: outlineSquareWithXViewModel,
+            action: { debugPrint("chipOutlineSquareImageLarge01 (X 버튼) 탭") },
+            content: { EmptyView() },
+            preset: .imgOutlineSquareLarge01
+        )
+        .toUIView(embeddedIn: self)
+        .detached(by: self.detachBag)
+        stackView.addArrangedSubview(outlineSquareWithXResult.view)
         
         stackView.addArrangedSubview(UIView())
         

--- a/Sources/DealiDesignKit/Components/Control/Chips/ChipConfigurable.swift
+++ b/Sources/DealiDesignKit/Components/Control/Chips/ChipConfigurable.swift
@@ -20,6 +20,18 @@ protocol ChipSizeProtoocol: ControlSizeProtocol {
     var imageSize: CGSize { get }
     var placeholderInset: CGFloat { get }
     var titleFont: FontProvider { get }
+    /// 사이즈별 패딩 오버라이드 (nil이면 ImageChip 기본값 사용)
+    var leftPadding: CGFloat? { get }
+    var rightPadding: CGFloat? { get }
+    var verticalPadding: CGFloat? { get }
+    var interItemSpacing: CGFloat? { get }
+}
+
+extension ChipSizeProtoocol {
+    var leftPadding: CGFloat? { nil }
+    var rightPadding: CGFloat? { nil }
+    var verticalPadding: CGFloat? { nil }
+    var interItemSpacing: CGFloat? { nil }
 }
 
 protocol ChipColorProtocol {

--- a/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/DealiControl+ImageChip.swift
+++ b/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/DealiControl+ImageChip.swift
@@ -34,12 +34,36 @@ public extension DealiControl {
             )
         )
     }
+    
+    static func chipOutlineSquareImageLarge01() -> ImageChip {
+        let chip = ImageChip(
+            configuration: ImageChipConfig(
+                size: ImageChipSizeType.outlineSquareImageLarge.size,
+                style: ImageStyleType.outlineSquare01.style
+            )
+        )
+        chip.placeholderImage = nil
+        return chip
+    }
+    
+    static func chipOutlineSquareImageMedium01() -> ImageChip {
+        let chip = ImageChip(
+            configuration: ImageChipConfig(
+                size: ImageChipSizeType.outlineSquareImageMedium.size,
+                style: ImageStyleType.outlineSquare01.style
+            )
+        )
+        chip.placeholderImage = nil
+        return chip
+    }
 }
 
 enum ImageChipSizeType {
     case large
     case medium
     case small
+    case outlineSquareImageLarge
+    case outlineSquareImageMedium
     
     var size: ChipSize {
         switch self {
@@ -64,6 +88,28 @@ enum ImageChipSizeType {
                 placeholderInset: 6.0,
                 titleFont: DealiFont.b2Regular
             )
+        case .outlineSquareImageLarge:
+            return ChipSize(
+                height: 46.0,
+                imageSize: .init(width: 12.0, height: 12.0),
+                placeholderInset: 0,
+                titleFont: DealiFont.b2SemiBold,
+                leftPadding: 12.0,
+                rightPadding: 12.0,
+                verticalPadding: 10.0,
+                interItemSpacing: 4.0
+            )
+        case .outlineSquareImageMedium:
+            return ChipSize(
+                height: 40.0,
+                imageSize: .init(width: 12.0, height: 12.0),
+                placeholderInset: 0,
+                titleFont: DealiFont.b2SemiBold,
+                leftPadding: 12.0,
+                rightPadding: 12.0,
+                verticalPadding: 10.0,
+                interItemSpacing: 4.0
+            )
         }
     }
 }
@@ -71,6 +117,7 @@ enum ImageChipSizeType {
 
 enum ImageStyleType {
     case basic
+    case outlineSquare01
     
     var style: ChipStyle {
         switch self {
@@ -81,6 +128,15 @@ enum ImageStyleType {
                     normal: ChipColor(textColor: UIColor.g80, backgroundColor: UIColor.b5),
                     selected: ChipColor(textColor: UIColor.primary04, backgroundColor: UIColor.g100),
                     disabled: ChipColor(textColor: UIColor.g50, backgroundColor: UIColor.b5)
+                )
+            )
+        case .outlineSquare01:
+            return ChipStyle(
+                radiusProvider: ChipRadiusType.fixed(4.0),
+                colorProvider: ChipColors(
+                    normal: ChipColor(textColor: UIColor.g100, backgroundColor: UIColor.primary04, borderColor: UIColor.g20),
+                    selected: ChipColor(textColor: UIColor.g100, backgroundColor: UIColor.primary04, borderColor: UIColor.g20),
+                    disabled: ChipColor(textColor: UIColor.g50, backgroundColor: UIColor.primary04, borderColor: UIColor.g20)
                 )
             )
         }

--- a/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/ImageChip.swift
+++ b/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/ImageChip.swift
@@ -51,6 +51,9 @@ public class ImageChip: DealiChip {
     public var placeholderImage: UIImage? = UIImage.dealiIcon(named: "ic_home_filled") {
         didSet {
             self.placeholderImageView.image = self.placeholderImage
+            if self.placeholderImage == nil {
+                self.placeholderImageView.isHidden = true
+            }
         }
     }
     
@@ -93,9 +96,19 @@ public class ImageChip: DealiChip {
     public var rightImage: UIImage? {
         didSet {
             self.rightIconImageView.isHidden = (rightImage == nil)
+            self.updateRightIconButtonVisibility()
             self.updateContent()
         }
     }
+    
+    /// 우측 아이콘(X 등)만 탭했을 때 호출
+    public var onRightIconTap: (() -> Void)? {
+        didSet {
+            self.updateRightIconButtonVisibility()
+        }
+    }
+    
+    private let rightIconButton = UIButton(type: .custom)
     
     public override var isHighlighted: Bool {
         didSet {
@@ -134,10 +147,10 @@ public class ImageChip: DealiChip {
             $0.layer.cornerRadius = self.configuration.imageSize.width / 2
             $0.backgroundColor = UIColor.primary04
         }.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(self.configuration.verticalPadding)
+            $0.centerY.equalToSuperview()
             $0.left.equalToSuperview().inset(self.configuration.leftPadding)
-            $0.width.height.equalTo(self.configuration.imageSize.width)
-            $0.size.equalTo(self.configuration.imageSize)
+            $0.width.equalTo(self.configuration.imageSize.width)
+            $0.height.equalTo(self.configuration.imageSize.height)
         }
         
         self.imageView.addSubview(self.placeholderImageView)
@@ -166,7 +179,9 @@ public class ImageChip: DealiChip {
             $0.font = self.configuration.titleFont
             $0.textAlignment = .left
             $0.text = "imageChip"
-            $0.sizeToFit()
+            $0.numberOfLines = 1
+            $0.lineBreakMode = .byTruncatingTail
+            $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         }
         
         self.contentStackView.addArrangedSubview(self.slotContainerView)
@@ -184,7 +199,26 @@ public class ImageChip: DealiChip {
             $0.size.equalTo(self.configuration.rightIconImageSize)
         }
         
+        self.addSubview(self.rightIconButton)
+        self.rightIconButton.then {
+            $0.backgroundColor = .clear
+            $0.isHidden = true
+            $0.addTarget(self, action: #selector(self.handleRightIconTap), for: .touchUpInside)
+        }.snp.makeConstraints {
+            $0.top.bottom.trailing.equalToSuperview()
+            $0.width.equalTo(44.0)
+        }
+        
         self.updateContent()
+    }
+    
+    private func updateRightIconButtonVisibility() {
+        let showButton = (self.rightImage != nil && self.onRightIconTap != nil)
+        self.rightIconButton.isHidden = !showButton
+    }
+    
+    @objc private func handleRightIconTap() {
+        self.onRightIconTap?()
     }
 
     override func updateUI(for state: DealiChipStatus) {
@@ -197,7 +231,6 @@ public class ImageChip: DealiChip {
         
         self.titleLabel.font = self.configuration.titleFont
         self.titleLabel.textColor = self.configuration.textColor
-        self.titleLabel.sizeToFit()
         self.rightIconImageView.image = self.rightImage?.withTintColor(self.configuration.textColor)
         self.invalidateIntrinsicContentSize()
         
@@ -222,6 +255,8 @@ public class ImageChip: DealiChip {
         if let borderColor = color.borderColor {
             self.layer.borderColor = borderColor.cgColor
             self.layer.borderWidth = 1.0
+        } else {
+            self.layer.borderWidth = 0.0
         }
     }
 }

--- a/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/ImageChipConfig.swift
+++ b/Sources/DealiDesignKit/Components/Control/Chips/ImageChips/ImageChipConfig.swift
@@ -35,13 +35,17 @@ class ImageChipConfig: ChipConfigurable {
         return self.style.radiusProvider.getRadius(for: self.height)
     }
      
-    init(size: any ChipSizeProtoocol,
-         style: any ChipStyleProtocol) {
+    init(size: some ChipSizeProtoocol,
+         style: some ChipStyleProtocol) {
         
         self.size = size
         self.height = size.height
         self.imageSize = size.imageSize
         self.placeholderInset = size.placeholderInset
+        self.leftPadding = size.leftPadding ?? 4.0
+        self.rightPadding = size.rightPadding ?? 12.0
+        self.verticalPadding = size.verticalPadding ?? 4.0
+        self.interItemSpacing = size.interItemSpacing ?? 8.0
         
         self.style = style
         
@@ -72,7 +76,7 @@ class ImageChipConfig: ChipConfigurable {
     func configColor(_ color: ChipColorProtocol) {
         self.backgroundColor = color.backgroundColor
         self.textColor = color.textColor
-        self.borderColor = color.backgroundColor
+        self.borderColor = color.borderColor
     }
 }
 
@@ -81,6 +85,30 @@ struct ChipSize: ChipSizeProtoocol {
     var imageSize: CGSize
     var placeholderInset: CGFloat
     var titleFont: FontProvider
+    var leftPadding: CGFloat?
+    var rightPadding: CGFloat?
+    var verticalPadding: CGFloat?
+    var interItemSpacing: CGFloat?
+    
+    init(
+        height: CGFloat,
+        imageSize: CGSize,
+        placeholderInset: CGFloat,
+        titleFont: FontProvider,
+        leftPadding: CGFloat? = nil,
+        rightPadding: CGFloat? = nil,
+        verticalPadding: CGFloat? = nil,
+        interItemSpacing: CGFloat? = nil
+    ) {
+        self.height = height
+        self.imageSize = imageSize
+        self.placeholderInset = placeholderInset
+        self.titleFont = titleFont
+        self.leftPadding = leftPadding
+        self.rightPadding = rightPadding
+        self.verticalPadding = verticalPadding
+        self.interItemSpacing = interItemSpacing
+    }
 }
 
 struct ChipColors: ColorProvider {

--- a/Sources/DealiDesignKit/SwiftUIComponents/Control/ImageChip/DLImageChipStyle.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/Control/ImageChip/DLImageChipStyle.swift
@@ -51,10 +51,14 @@ struct DLImageChipConfig: ChipConfigurable {
             imageSize: size.imageSize,
             cornerRadius: self.style.radiusProvider.getRadius(for: size.height),
             placeholderInset: size.placeholderInset,
+            leftPadding: size.leftPadding ?? 4.0,
+            interItemSpacing: size.interItemSpacing ?? 8.0,
+            rightPadding: size.rightPadding ?? 12.0,
+            verticalPadding: size.verticalPadding ?? 4.0,
             titleFont: titleFont,
             textColor: Color(color.textColor),
             backgroundColor: Color(color.backgroundColor),
-            borderColor: Color(color.borderColor ?? UIColor.clear)
+            borderColor: color.borderColor.map { Color($0) }
         )
     }
      
@@ -78,7 +82,9 @@ public enum ImageChipPreset: CaseIterable {
     case imgChipLarge01
     case imgChipMedium01
     case imgChipSmall01
-    
+    case imgOutlineSquareLarge01
+    case imgOutlineSquareMedium01
+
     var config: DLImageChipConfig {
         switch self {
         case .imgChipLarge01:
@@ -95,6 +101,17 @@ public enum ImageChipPreset: CaseIterable {
             return DLImageChipConfig(
                 size: ImageChipSizeType.small.size,
                 style: ImageStyleType.basic.style
+            )
+        case .imgOutlineSquareLarge01:
+            return DLImageChipConfig(
+                size: ImageChipSizeType.outlineSquareImageLarge.size,
+                style: ImageStyleType.outlineSquare01.style
+            )
+            
+        case .imgOutlineSquareMedium01:
+            return DLImageChipConfig(
+                size: ImageChipSizeType.outlineSquareImageMedium.size,
+                style: ImageStyleType.outlineSquare01.style
             )
         }
     }

--- a/Sources/DealiDesignKit/SwiftUIComponents/Control/ImageChip/DealiImageChip.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/Control/ImageChip/DealiImageChip.swift
@@ -98,6 +98,14 @@ public struct DealiImageChip<Content: View>: View {
             .padding(.trailing, style.rightPadding)
             .background(style.backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
+            .overlay(
+                Group {
+                    if let borderColor = style.borderColor {
+                        RoundedRectangle(cornerRadius: style.cornerRadius)
+                            .stroke(borderColor, lineWidth: 1)
+                    }
+                }
+            )
         }
         .disabled(viewModel.status == .disabled)
     }


### PR DESCRIPTION
## PR 마감기한


## 작업 내용
- chipOutlineSquareImage 컴포넌트를 추가하였습니다. 
<img width="669" height="229" alt="스크린샷 2026-03-16 오후 2 54 47" src="https://github.com/user-attachments/assets/ec0f8e51-c263-460e-8353-f54e48d9b3cc" />

<img width="696" height="203" alt="스크린샷 2026-03-16 오후 2 54 31" src="https://github.com/user-attachments/assets/dfd92b4f-b8a7-43dd-925c-847324e6e39b" />

## Merge 전 필요한 작업
- N/A

## 주의해서 봐야 할 부분
- 문제 없는지 테스트 해주세요
