### PR TITLE
[MP-7035] 바텀시트 하단 버튼 용도/배치 확장 (v.2.69)

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		3B92CD052D62CE96006A2057 /* AlertTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B92CD042D62CE96006A2057 /* AlertTestView.swift */; };
 		4D1FA9292AFC778E00AA510F /* SwitchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1FA9282AFC778E00AA510F /* SwitchViewController.swift */; };
 		4D4C2B4E2DD2F073000B482A /* ToastTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C2B4D2DD2F073000B482A /* ToastTestView.swift */; };
+		BB7E51A02D0000000000A002 /* BottomSheetTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7E51A02D0000000000A001 /* BottomSheetTestView.swift */; };
 		4D50A85D2DAF4F3500A39FB0 /* ComponentHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D50A85C2DAF4F3500A39FB0 /* ComponentHeaderView.swift */; };
 		4D50A85F2DAF543300A39FB0 /* SearchBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D50A85E2DAF543300A39FB0 /* SearchBarCell.swift */; };
 		4D5326D52AB15FFF00A9509A /* ButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5326D42AB15FFF00A9509A /* ButtonViewController.swift */; };
@@ -108,6 +109,7 @@
 		3B92CD042D62CE96006A2057 /* AlertTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertTestView.swift; sourceTree = "<group>"; };
 		4D1FA9282AFC778E00AA510F /* SwitchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewController.swift; sourceTree = "<group>"; };
 		4D4C2B4D2DD2F073000B482A /* ToastTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastTestView.swift; sourceTree = "<group>"; };
+		BB7E51A02D0000000000A001 /* BottomSheetTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetTestView.swift; sourceTree = "<group>"; };
 		4D50A85C2DAF4F3500A39FB0 /* ComponentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentHeaderView.swift; sourceTree = "<group>"; };
 		4D50A85E2DAF543300A39FB0 /* SearchBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarCell.swift; sourceTree = "<group>"; };
 		4D5326D42AB15FFF00A9509A /* ButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonViewController.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				5FEF63692D966F2400248F3E /* TextLinkTestView.swift */,
 				4DA7ED742D9BFFA80029165D /* SearchInputTestView.swift */,
 				4D4C2B4D2DD2F073000B482A /* ToastTestView.swift */,
+				BB7E51A02D0000000000A001 /* BottomSheetTestView.swift */,
 				4DD5C2662DE5A46B00EEDB02 /* ImageChipTestView.swift */,
 			);
 			path = SwiftUIBase;
@@ -579,6 +582,7 @@
 				041ABC0C2A175E19001772F3 /* ColorViewController.swift in Sources */,
 				E6EA11A42A8A24DC00ACCF3B /* AlertTestViewController.swift in Sources */,
 				4D4C2B4E2DD2F073000B482A /* ToastTestView.swift in Sources */,
+				BB7E51A02D0000000000A002 /* BottomSheetTestView.swift in Sources */,
 				396EF4BC2BD8F129006CEF43 /* CheckComponentViewController.swift in Sources */,
 				4DA7ED892DA7AECE0029165D /* ComponentCollectionViewCell.swift in Sources */,
 				E6C115E52BE4855A00032960 /* IndicatorViewController.swift in Sources */,

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Main/FullSwiftUIBaseView.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Main/FullSwiftUIBaseView.swift
@@ -15,6 +15,7 @@ import DealiDesignKit
 struct FullSwiftUIBaseView: View {
     let components: [Component] = [
         Component(title: "Alert", linkView: AlertTestView()),
+        Component(title: "BottomSheet", linkView: BottomSheetTestView()),
         Component(title: "Button", linkView: ButtonTestView()),
         Component(title: "Checkbox", linkView: CheckboxTestView()),
         Component(title: "EmptyView", linkView: EmptyViewTest()),

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/SwiftUIBase/BottomSheetTestView.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/SwiftUIBase/BottomSheetTestView.swift
@@ -1,0 +1,132 @@
+//
+//  BottomSheetTestView.swift
+//  DealiDesignSystemSampleApp
+//
+//  Created by jalynneyoon on 7/28/26.
+//  Copyright © 2026 Dealicious Inc. All rights reserved.
+//
+
+import SwiftUI
+import DealiDesignKit
+
+struct BottomSheetTestView: View {
+
+    private struct Sample: Identifiable {
+        let id = UUID()
+        /// 버튼 개수 / 용도 / 배치 이름
+        let layoutName: String
+        /// 바텀시트 타이틀에 노출할 전체 조합 이름
+        let fullName: String
+        let buttonType: EBottomSheetButtonType
+    }
+
+    private struct UsageGroup: Identifiable {
+        let id = UUID()
+        let name: String
+        let samples: [Sample]
+    }
+
+    @StateObject private var sheetState = DealiSheetState()
+    @State private var selectedSample: Sample?
+
+    private let usageGroups: [UsageGroup] = {
+        let usages: [(name: String, usage: EBottomSheetButtonUsage)] = [
+            ("Default", .default),
+            ("도매 멤버십", .wholesaleMembership),
+            ("소매 멤버십1", .retailMembership01),
+            ("소매 멤버십2", .retailMembership02),
+            ("커스텀 조합", EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge06, optionButtonStyle: .btnOutlineLarge04))
+        ]
+
+        let layouts: [(name: String, makeButtonType: (EBottomSheetButtonUsage) -> EBottomSheetButtonType)] = [
+            ("1btn", { .oneButton(buttonTitle: "Button", usage: $0) }),
+            ("option 좌우", { .twoButton(confirmTitle: "Option Button", cancelTitle: "Option Button", cancelButtonType: .option, usage: $0, axis: .horizontal) }),
+            ("option 상하", { .twoButton(confirmTitle: "Option Button", cancelTitle: "Option Button", cancelButtonType: .option, usage: $0, axis: .vertical) }),
+            ("cancel 좌우", { .twoButton(confirmTitle: "Confirm Button", cancelTitle: "Cancel Button", cancelButtonType: .cancel, usage: $0, axis: .horizontal) }),
+            ("cancel 상하", { .twoButton(confirmTitle: "Confirm Button", cancelTitle: "Cancel Button", cancelButtonType: .cancel, usage: $0, axis: .vertical) })
+        ]
+
+        return usages.map { usageSample in
+            UsageGroup(
+                name: usageSample.name,
+                samples: layouts.map { layoutSample in
+                    Sample(layoutName: layoutSample.name,
+                           fullName: "\(usageSample.name) / \(layoutSample.name)",
+                           buttonType: layoutSample.makeButtonType(usageSample.usage))
+                }
+            )
+        }
+    }()
+
+    private let gridColumns = [GridItem(.flexible(), spacing: 8.0), GridItem(.flexible(), spacing: 8.0)]
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 28.0) {
+                    ForEach(usageGroups) { group in
+                        usageGroupView(group)
+                    }
+                }
+                .padding(.horizontal, 16.0)
+                .padding(.vertical, 24.0)
+            }
+            .background(Color.primary04)
+
+            sheetView
+        }
+        .navigationBarTitle("BottomSheet", displayMode: .inline)
+    }
+}
+
+private extension BottomSheetTestView {
+    private func usageGroupView(_ group: UsageGroup) -> some View {
+        VStack(alignment: .leading, spacing: 12.0) {
+            Text(group.name)
+                .font(.b1sb15)
+                .foregroundStyle(Color.g100)
+
+            Rectangle()
+                .fill(Color.g20)
+                .frame(height: 1.0)
+
+            LazyVGrid(columns: gridColumns, spacing: 8.0) {
+                ForEach(group.samples) { sample in
+                    ButtonView(
+                        viewModel: .init(type: .btnOutlineBgSemiMedium01, title: sample.layoutName),
+                        action: { present(sample) }
+                    )
+                }
+            }
+        }
+    }
+
+    var sheetView: some View {
+        DealiSheetView(
+            title: selectedSample?.fullName,
+            showCloseButton: true,
+            fixedHeight: 320.0,
+            buttonType: selectedSample?.buttonType ?? .hidden,
+            onConfirm: { print("confirm 클릭") },
+            onCancel: { print("cancel 클릭") }
+        ) {
+            Text("하단 버튼의 사용처 / 용도 / 배치 조합 확인용 바텀시트입니다.")
+                .font(.b2r14)
+                .foregroundStyle(Color.g80)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .padding(.horizontal, 16.0)
+        }
+        .environmentObject(sheetState)
+    }
+
+    private func present(_ sample: Sample) {
+        selectedSample = sample
+        sheetState.isPresented = true
+    }
+}
+
+#Preview {
+    NavigationView {
+        BottomSheetTestView()
+    }
+}

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/0. Main/ComponentSectionData.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/0. Main/ComponentSectionData.swift
@@ -92,7 +92,7 @@ enum ActionType: Hashable, CaseIterable {
         switch self {
         case  .typography,
                 .button, .searchInput, .checkbox,.imageChip, .chip, .tag, .dropdown,
-                .alert, .empty, .tabBar, .toast:
+                .alert, .bottomSheet, .empty, .tabBar, .toast:
             return true
         default:
             return false
@@ -194,7 +194,7 @@ extension ItemData {
         case .alert:
             AlertTestViewController(isSwiftUI: isSwiftUI)
         case .bottomSheet:
-            BottomSheetPopupTestViewController()
+            BottomSheetPopupTestViewController(isSwiftUI: isSwiftUI)
         case .empty:
             if type.hasSwiftUISample {
                 EmptyViewController(isSwiftUI: true)

--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/BottomSheetPopupTestViewController.swift
@@ -8,12 +8,42 @@
 
 import UIKit
 import DealiDesignKit
+import SwiftUI
 import RxSwift
 import RxCocoa
 
 final class BottomSheetPopupTestViewController: UIViewController {
-    
+
     let disposeBag = DisposeBag()
+    private let isSwiftUI: Bool
+
+    /// 하단 버튼 사용처(테마) 샘플. 라이브러리에 정의된 사용처 + 호출부에서 직접 만든 조합
+    private let buttonUsageSamples: [(name: String, usage: EBottomSheetButtonUsage)] = [
+        ("Default", .default),
+        ("도매 멤버십", .wholesaleMembership),
+        ("소매 멤버십1", .retailMembership01),
+        ("소매 멤버십2", .retailMembership02),
+        ("커스텀 조합", EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge06, optionButtonStyle: .btnOutlineLarge04))
+    ]
+
+    /// 버튼 개수 / 용도 / 배치 조합 샘플
+    private let buttonLayoutSamples: [(name: String, makeButtonType: (EBottomSheetButtonUsage) -> EBottomSheetButtonType)] = [
+        ("1btn", { .oneButton(buttonTitle: "Button", usage: $0) }),
+        ("2btn option 좌우", { .twoButton(confirmTitle: "Option Button", cancelTitle: "Option Button", cancelButtonType: .option, usage: $0, axis: .horizontal) }),
+        ("2btn option 상하", { .twoButton(confirmTitle: "Option Button", cancelTitle: "Option Button", cancelButtonType: .option, usage: $0, axis: .vertical) }),
+        ("2btn cancel 좌우", { .twoButton(confirmTitle: "Confirm Button", cancelTitle: "Cancel Button", cancelButtonType: .cancel, usage: $0, axis: .horizontal) }),
+        ("2btn cancel 상하", { .twoButton(confirmTitle: "Confirm Button", cancelTitle: "Cancel Button", cancelButtonType: .cancel, usage: $0, axis: .vertical) })
+    ]
+
+    init(isSwiftUI: Bool = false) {
+        self.isSwiftUI = isSwiftUI
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,7 +54,18 @@ final class BottomSheetPopupTestViewController: UIViewController {
 
     override func loadView() {
         super.loadView()
-        
+
+        if self.isSwiftUI {
+            let hostingController = UIHostingController(rootView: BottomSheetTestView())
+            self.addChild(hostingController)
+            self.view.addSubview(hostingController.view)
+            hostingController.view.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+            hostingController.didMove(toParent: self)
+            return
+        }
+
         let contentScrollView = UIScrollView()
         self.view.addSubview(contentScrollView)
         contentScrollView.then {
@@ -124,11 +165,41 @@ final class BottomSheetPopupTestViewController: UIViewController {
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
         }
+
+        self.buttonUsageSamples.forEach { usageSample in
+            self.buttonLayoutSamples.forEach { layoutSample in
+                let title = "\(usageSample.name) / \(layoutSample.name)"
+                let buttonType = layoutSample.makeButtonType(usageSample.usage)
+
+                let sampleButton = DealiControl.btnOutlineLarge01()
+                contentStackView.addArrangedSubview(sampleButton)
+                sampleButton.then {
+                    $0.title = title
+                    $0.numberOfLines = 0
+                }.snp.makeConstraints {
+                    $0.left.right.equalToSuperview()
+                }
+
+                sampleButton.rx.tap.asSignal().emit(with: self) { owner, _ in
+                    owner.showButtonSample(title: title, buttonType: buttonType)
+                }.disposed(by: self.disposeBag)
+            }
+        }
     }
 
 }
 
 extension BottomSheetPopupTestViewController {
+    private func showButtonSample(title: String, buttonType: EBottomSheetButtonType) {
+        DealiBottomSheet.showTextOnly(
+            titleType: .titleCloseButton(title: title),
+            message: "하단 버튼의 사용처 / 용도 / 배치 조합 확인용 바텀시트입니다.",
+            buttonType: buttonType,
+            popupPresentingViewController: self,
+            cancelAction: nil, confirmAction: nil
+        )
+    }
+
     @objc func bottomSheetPopupButton01Pressed() {
         debugPrint("bottomSheetPopupButton01Pressed")
 

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift
@@ -43,17 +43,6 @@ public enum EBottomSheetTitleType: Equatable {
     case titleCloseButton(title: String?)
 }
 
-public enum EBottomSheetButtonType: Equatable {
-    case hidden
-    case oneButton(buttonTitle: String?)
-    case twoButton(confirmTitle: String?, cancelTitle: String?, cancelButtonType: EBottomSheetCancelButtonType? = .btnOutlineLarge01)
-}
-
-public enum EBottomSheetCancelButtonType {
-    case btnOutlineLarge01
-    case btnOutlineLarge06
-}
-
 public class DealiBottomSheet: NSObject {
     
     public class func showSingleSelectionType(
@@ -265,7 +254,7 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
     
     var optionHeight: CGFloat {
         let titleHeight = 60.0
-        let buttonContentHeight = self.buttonType == .hidden ? 0 : 74.0 + safeAreaBottomMargin
+        let buttonContentHeight = self.buttonType.isHidden ? 0 : self.buttonType.contentHeight + safeAreaBottomMargin
         let maximumContentHeight = UIScreen.main.bounds.size.height * 0.9 - titleHeight - buttonContentHeight
         let contentHeight = CGFloat(self.optionData.count) * 52.0
         return min(maximumContentHeight, contentHeight)
@@ -299,20 +288,7 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
             $0.textColor = .g100
         }
     }()
-     
-    private lazy var cancelButton: ClickableUnitButtonComponent = {
-        return DealiControl.btnOutlineLarge01().then {
-            $0.numberOfLines = 0
-        }
-    }()
-    
-    private lazy var confirmButton: ClickableUnitButtonComponent = {
-        return DealiControl.btnFilledLarge01().then {
-            $0.addTarget(self, action: #selector(confirmButtonAction), for: .touchUpInside)
-            $0.numberOfLines = 0
-        }
-    }()
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -369,7 +345,7 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
             if self.optionType != nil {
                 contentContainerView.addSubview(self.collectionView)
                 let titleHeight = 60.0
-                let buttonContentHeight = self.buttonType == .hidden ? 0 : 74.0 + safeAreaBottomMargin
+                let buttonContentHeight = self.buttonType.isHidden ? 0 : self.buttonType.contentHeight + safeAreaBottomMargin
                 let maximumContentHeight = UIScreen.main.bounds.size.height * 0.8 - titleHeight - buttonContentHeight
                 
                 self.collectionView.then {
@@ -388,12 +364,12 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
                 }
             }
             
-            if self.buttonType != .hidden {
+            if self.buttonType.isHidden == false {
                 self.contentStackView.setCustomSpacing(12.0, after: contentContainerView)
             }
         }
-        
-        if self.buttonType != .hidden {
+
+        if self.buttonType.isHidden == false {
             let buttonContainerView = self.buttonContainerView()
             self.contentStackView.addArrangedSubview(buttonContainerView)
             buttonContainerView.snp.makeConstraints {
@@ -405,45 +381,66 @@ class DealiBottomSheetSystemViewController: DealiBottomSheetBaseViewController {
     
     private func buttonContainerView() -> UIView {
         let buttonContainerView = UIView()
-        
+
+        let isVertical: Bool
+        if case .twoButton(_, _, _, _, let axis) = self.buttonType, axis == .vertical {
+            isVertical = true
+        } else {
+            isVertical = false
+        }
+
         let buttonStackView = UIStackView()
         buttonContainerView.addSubview(buttonStackView)
         buttonStackView.then {
-            $0.axis = .horizontal
+            $0.axis = isVertical ? .vertical : .horizontal
             $0.alignment = .fill
-            $0.distribution = .fillEqually
-            $0.spacing = 8.0
+            $0.distribution = isVertical ? .fill : .fillEqually
+            $0.spacing = EBottomSheetButtonType.buttonSpacing
         }.snp.makeConstraints {
             $0.top.bottom.equalToSuperview().inset(12.0)
             $0.left.right.equalToSuperview()
         }
-        
+
+        let usage = self.buttonType.usage
+
         switch self.buttonType {
-        case .oneButton(let title):
-            buttonStackView.addArrangedSubview(self.confirmButton)
-            self.confirmButton.title = title
-            self.confirmButton.snp.makeConstraints {
+        case .oneButton(let title, _):
+            let confirmButton = self.makeConfirmButton(style: usage.confirmButtonStyle, title: title)
+            buttonStackView.addArrangedSubview(confirmButton)
+            confirmButton.snp.makeConstraints {
                 $0.top.bottom.equalToSuperview()
             }
-        case .twoButton(let confirmTitle, let cancelTitle, let cancelButtonType):
-            self.cancelButton = cancelButtonType == .btnOutlineLarge01 ? DealiControl.btnOutlineLarge01() : DealiControl.btnOutlineLarge06()
-            self.cancelButton.addTarget(self, action: #selector(cancelButtonAction), for: .touchUpInside)
-            buttonStackView.addArrangedSubview(self.cancelButton)
-            self.cancelButton.title = cancelTitle
-            self.cancelButton.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
+        case .twoButton(let confirmTitle, let cancelTitle, let cancelButtonType, _, _):
+            let confirmButton = self.makeConfirmButton(style: usage.confirmButtonStyle, title: confirmTitle)
+            let cancelButton = usage.subButtonStyle(for: cancelButtonType).makeButton().then {
+                $0.addTarget(self, action: #selector(cancelButtonAction), for: .touchUpInside)
+                $0.numberOfLines = 0
+                $0.title = cancelTitle
             }
-            
-            buttonStackView.addArrangedSubview(self.confirmButton)
-            self.confirmButton.title = confirmTitle
-            self.confirmButton.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
+
+            // 좌우 배치는 보조 → 확인, 상하 배치는 확인 → 보조 순서다
+            let orderedButtons = isVertical ? [confirmButton, cancelButton] : [cancelButton, confirmButton]
+            orderedButtons.forEach { button in
+                buttonStackView.addArrangedSubview(button)
+                // 상하 배치에서는 두 버튼이 stack 전체 높이를 채우려 해 제약이 충돌하므로 버튼의 intrinsic height에 맡긴다
+                guard isVertical == false else { return }
+                button.snp.makeConstraints {
+                    $0.top.bottom.equalToSuperview()
+                }
             }
         default:
             break
         }
-        
+
         return buttonContainerView
+    }
+
+    private func makeConfirmButton(style: EBottomSheetButtonStyle, title: String?) -> ClickableUnitButtonComponent {
+        return style.makeButton().then {
+            $0.addTarget(self, action: #selector(confirmButtonAction), for: .touchUpInside)
+            $0.numberOfLines = 0
+            $0.title = title
+        }
     }
     
     @objc func cancelButtonAction() {

--- a/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheetButtonStyle.swift
+++ b/Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheetButtonStyle.swift
@@ -1,0 +1,204 @@
+//
+//  DealiBottomSheetButtonStyle.swift
+//
+//
+//  Created by jalynneyoon on 7/28/26.
+//
+
+import UIKit
+import SwiftUI
+
+/**
+ 설명: 바텀시트 하단 버튼에 쓸 수 있는 large 버튼 스타일. UIKit/SwiftUI 매핑의 단일 소스다.
+ */
+public enum EBottomSheetButtonStyle {
+    case btnFilledLarge01
+    case btnFilledLarge02
+    case btnFilledLarge03
+    case btnFilledLarge04
+    case btnFilledLarge05
+    case btnFilledLarge06
+    case btnOutlineLarge01
+    case btnOutlineLarge02
+    case btnOutlineLarge03
+    case btnOutlineLarge04
+    case btnOutlineLarge05
+    case btnOutlineLarge06
+
+    func makeButton() -> ClickableUnitButtonComponent {
+        switch self {
+        case .btnFilledLarge01:
+            return DealiControl.btnFilledLarge01()
+        case .btnFilledLarge02:
+            return DealiControl.btnFilledLarge02()
+        case .btnFilledLarge03:
+            return DealiControl.btnFilledLarge03()
+        case .btnFilledLarge04:
+            return DealiControl.btnFilledLarge04()
+        case .btnFilledLarge05:
+            return DealiControl.btnFilledLarge05()
+        case .btnFilledLarge06:
+            return DealiControl.btnFilledLarge06()
+        case .btnOutlineLarge01:
+            return DealiControl.btnOutlineLarge01()
+        case .btnOutlineLarge02:
+            return DealiControl.btnOutlineLarge02()
+        case .btnOutlineLarge03:
+            return DealiControl.btnOutlineLarge03()
+        case .btnOutlineLarge04:
+            return DealiControl.btnOutlineLarge04()
+        case .btnOutlineLarge05:
+            return DealiControl.btnOutlineLarge05()
+        case .btnOutlineLarge06:
+            return DealiControl.btnOutlineLarge06()
+        }
+    }
+
+    var buttonConfigStyle: ButtonView.ButtonConfigStyle {
+        switch self {
+        case .btnFilledLarge01:
+            return .btnFilledLarge01
+        case .btnFilledLarge02:
+            return .btnFilledLarge02
+        case .btnFilledLarge03:
+            return .btnFilledLarge03
+        case .btnFilledLarge04:
+            return .btnFilledLarge04
+        case .btnFilledLarge05:
+            return .btnFilledLarge05
+        case .btnFilledLarge06:
+            return .btnFilledLarge06
+        case .btnOutlineLarge01:
+            return .btnOutlineLarge01
+        case .btnOutlineLarge02:
+            return .btnOutlineLarge02
+        case .btnOutlineLarge03:
+            return .btnOutlineLarge03
+        case .btnOutlineLarge04:
+            return .btnOutlineLarge04
+        case .btnOutlineLarge05:
+            return .btnOutlineLarge05
+        case .btnOutlineLarge06:
+            return .btnOutlineLarge06
+        }
+    }
+}
+
+/**
+ 설명: 바텀시트 하단 버튼 사용처(테마). confirm / option / cancel 버튼 스타일 한 벌을 묶는다.
+ */
+public struct EBottomSheetButtonUsage: Equatable {
+    /// 확인 버튼 스타일
+    public let confirmButtonStyle: EBottomSheetButtonStyle
+    /// 용도가 option일 때의 보조 버튼 스타일
+    public let optionButtonStyle: EBottomSheetButtonStyle
+    /// 용도가 cancel일 때의 보조 버튼 스타일
+    public let cancelButtonStyle: EBottomSheetButtonStyle
+
+    public init(confirmButtonStyle: EBottomSheetButtonStyle,
+                optionButtonStyle: EBottomSheetButtonStyle,
+                cancelButtonStyle: EBottomSheetButtonStyle = .btnOutlineLarge06) {
+        self.confirmButtonStyle = confirmButtonStyle
+        self.optionButtonStyle = optionButtonStyle
+        self.cancelButtonStyle = cancelButtonStyle
+    }
+
+    /// 사용처 = Default
+    public static let `default` = EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge01,
+                                                          optionButtonStyle: .btnOutlineLarge01)
+    /// 사용처 = 도매 멤버십
+    public static let wholesaleMembership = EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge02,
+                                                                    optionButtonStyle: .btnOutlineLarge01)
+    /// 사용처 = 소매 멤버십1
+    public static let retailMembership01 = EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge04,
+                                                                   optionButtonStyle: .btnOutlineLarge03)
+    /// 사용처 = 소매 멤버십2
+    public static let retailMembership02 = EBottomSheetButtonUsage(confirmButtonStyle: .btnFilledLarge05,
+                                                                   optionButtonStyle: .btnOutlineLarge03)
+
+    /// 디자인 가이드에 정의된 사용처 목록
+    public static let allUsages: [EBottomSheetButtonUsage] = [.default, .wholesaleMembership, .retailMembership01, .retailMembership02]
+
+    func subButtonStyle(for cancelButtonType: EBottomSheetCancelButtonType?) -> EBottomSheetButtonStyle {
+        return (cancelButtonType ?? .option) == .cancel ? self.cancelButtonStyle : self.optionButtonStyle
+    }
+}
+
+/**
+ 설명: 바텀시트 하단 버튼 배치 방향
+ */
+public enum EBottomSheetButtonAxis {
+    /// 좌우 배치. 보조 버튼이 왼쪽, 확인 버튼이 오른쪽
+    case horizontal
+    /// 상하 배치. 확인 버튼이 위, 보조 버튼이 아래
+    case vertical
+}
+
+/**
+ 설명: 바텀시트 하단 보조 버튼의 용도
+ */
+public enum EBottomSheetCancelButtonType {
+    /// 사용처 테마에 맞는 outline 버튼
+    case option
+    /// secondary04 outline 버튼
+    case cancel
+
+    @available(*, deprecated, renamed: "option")
+    public static var btnOutlineLarge01: Self { .option }
+
+    @available(*, deprecated, renamed: "cancel")
+    public static var btnOutlineLarge06: Self { .cancel }
+}
+
+/**
+ 설명: 바텀시트 하단 버튼 영역 노출 타입
+ */
+public enum EBottomSheetButtonType: Equatable {
+    case hidden
+    case oneButton(buttonTitle: String?,
+                   usage: EBottomSheetButtonUsage = .default)
+    case twoButton(confirmTitle: String?,
+                   cancelTitle: String?,
+                   cancelButtonType: EBottomSheetCancelButtonType? = .option,
+                   usage: EBottomSheetButtonUsage = .default,
+                   axis: EBottomSheetButtonAxis = .horizontal)
+}
+
+extension EBottomSheetButtonType {
+    /// 버튼 영역 상하 여백
+    private static let verticalInset = 12.0
+    /// large 버튼 높이
+    private static let buttonHeight = 50.0
+    /// 버튼 사이 간격
+    static let buttonSpacing = 8.0
+
+    var isHidden: Bool {
+        return self == .hidden
+    }
+
+    /// safe area를 제외한 버튼 영역 전체 높이
+    var contentHeight: CGFloat {
+        switch self {
+        case .hidden:
+            return 0.0
+        case .oneButton:
+            return Self.verticalInset * 2.0 + Self.buttonHeight
+        case .twoButton(_, _, _, _, let axis):
+            guard axis == .vertical else {
+                return Self.verticalInset * 2.0 + Self.buttonHeight
+            }
+            return Self.verticalInset * 2.0 + Self.buttonHeight * 2.0 + Self.buttonSpacing
+        }
+    }
+
+    var usage: EBottomSheetButtonUsage {
+        switch self {
+        case .hidden:
+            return .default
+        case .oneButton(_, let usage):
+            return usage
+        case .twoButton(_, _, _, let usage, _):
+            return usage
+        }
+    }
+}

--- a/Sources/DealiDesignKit/SwiftUIComponents/BottomSheet/SwiftUIView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/BottomSheet/SwiftUIView.swift
@@ -37,8 +37,11 @@ public struct DealiSheetView<Content: View>: View {
     var heightRatio: CGFloat
     var fixedHeight: CGFloat
     var closeOnBackgroundTap: Bool
+    var buttonType: EBottomSheetButtonType
+    var onConfirm: (() -> Void)?
+    var onCancel: (() -> Void)?
     var content: Content
-    
+
     // MARK: - Init
     public init(
         title: String? = nil,
@@ -46,6 +49,9 @@ public struct DealiSheetView<Content: View>: View {
         heightRatio: CGFloat = 0.8,
         fixedHeight: CGFloat = 0.0,
         closeOnBackgroundTap: Bool = true,
+        buttonType: EBottomSheetButtonType = .hidden,
+        onConfirm: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.title = title
@@ -53,6 +59,9 @@ public struct DealiSheetView<Content: View>: View {
         self.heightRatio = heightRatio
         self.fixedHeight = fixedHeight
         self.closeOnBackgroundTap = closeOnBackgroundTap
+        self.buttonType = buttonType
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
         self.content = content()
     }
     
@@ -76,8 +85,12 @@ public struct DealiSheetView<Content: View>: View {
                         }
                         
                         content
-                            .padding(.bottom, geo.safeAreaInsets.bottom)
+
+                        if buttonType.isHidden == false {
+                            buttonView()
+                        }
                     }
+                    .padding(.bottom, geo.safeAreaInsets.bottom)
                     .frame(width: geo.size.width)
                     .frame(maxHeight: calculatedHeight(for: geo.size.height))
                     .fixedSize()
@@ -124,6 +137,48 @@ private extension DealiSheetView {
     func calculatedHeight(for totalHeight: CGFloat) -> CGFloat {
         fixedHeight > 0 ? fixedHeight : totalHeight * heightRatio
     }
+
+    /// 하단 버튼 영역
+    @ViewBuilder
+    func buttonView() -> some View {
+        Group {
+            switch buttonType {
+            case .hidden:
+                EmptyView()
+            case .oneButton(let title, let usage):
+                buttonItem(style: usage.confirmButtonStyle, title: title, action: confirmButtonAction)
+            case .twoButton(let confirmTitle, let cancelTitle, let cancelButtonType, let usage, let axis):
+                if axis == .vertical {
+                    VStack(spacing: EBottomSheetButtonType.buttonSpacing) {
+                        buttonItem(style: usage.confirmButtonStyle, title: confirmTitle, action: confirmButtonAction)
+                        buttonItem(style: usage.subButtonStyle(for: cancelButtonType), title: cancelTitle, action: cancelButtonAction)
+                    }
+                } else {
+                    HStack(spacing: EBottomSheetButtonType.buttonSpacing) {
+                        buttonItem(style: usage.subButtonStyle(for: cancelButtonType), title: cancelTitle, action: cancelButtonAction)
+                        buttonItem(style: usage.confirmButtonStyle, title: confirmTitle, action: confirmButtonAction)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 12.0)
+        .padding(.horizontal, 16.0)
+    }
+
+    func buttonItem(style: EBottomSheetButtonStyle, title: String?, action: @escaping () -> Void) -> some View {
+        ButtonView(type: style.buttonConfigStyle, title: title ?? "", action: action)
+            .frame(height: 50.0)
+    }
+
+    func confirmButtonAction() {
+        dismissSheet()
+        onConfirm?()
+    }
+
+    func cancelButtonAction() {
+        dismissSheet()
+        onCancel?()
+    }
 }
 
 #Preview {
@@ -148,30 +203,25 @@ private extension DealiSheetView {
                     
                     DealiSheetView(
                         title: "옵션 선택",
-                        showCloseButton: true
+                        showCloseButton: true,
+                        buttonType: .twoButton(confirmTitle: "확인",
+                                              cancelTitle: "취소",
+                                              cancelButtonType: .cancel,
+                                              usage: .retailMembership01,
+                                              axis: .vertical)
                     ) {
-                        VStack {
-                            ScrollView {
-                                VStack(spacing: 16) {
-                                    ForEach(0..<2) { i in
-                                        Text("옵션 \(i + 1)")
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.vertical, 8)
-                                            .background(Color(uiColor: .systemGray6))
-                                            .cornerRadius(8)
-                                    }
+                        ScrollView {
+                            VStack(spacing: 16) {
+                                ForEach(0..<2) { i in
+                                    Text("옵션 \(i + 1)")
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.vertical, 8)
+                                        .background(Color(uiColor: .systemGray6))
+                                        .cornerRadius(8)
                                 }
                             }
-                            .padding()
-                            
-                            HStack(spacing: 8) {
-                                ButtonView(type: .btnOutlineLarge01, title: "취소")
-                                ButtonView(type: .btnFilledLarge01, title: "확인")
-                            }
-                            .frame(height: 50.0)
-                            .padding(.vertical, 12)
-                            .padding(.horizontal, 16)
                         }
+                        .padding()
                     }
                     .environmentObject(DealiSheetState())
                 }


### PR DESCRIPTION
## 개요

디자인시스템 2.69 버전 요구사항을 반영하였습니다. 

[Figma `floating_Bt` 컴포넌트 세트](https://www.figma.com/design/5WsL9kg8fteVvSDUw4L1s6/-%EC%8B%A0%EC%83%81%EB%A7%88%EC%BC%93--M_Design-system-Guide?node-id=26152-27565&m=dev)가 `사용처`(테마) · `L/하단_btn 용도`(option/cancel) · `btn 위치`(horizontal/vertical) 세 축으로 확장되어, 바텀시트 하단 버튼이 이를 표현할 수 있게 했습니다.

**기존 호출부는 수정 없이 그대로 컴파일됩니다.**

---

## API 사용법

### 1. 기존 코드는 그대로

```swift
buttonType: .oneButton(buttonTitle: "확인")
buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소")
```

`usage` / `axis` 는 기본값이 있어 생략하면 Default 테마 · 좌우 배치입니다. 기존 화면은 손댈 필요가 없습니다.

### 2. 사용처(테마) — `usage`

`usage:` 하나만 넘기면 확인 버튼 색과 option 보조 버튼 색이 한 벌로 따라옵니다.

```swift
DealiBottomSheet.showTextOnly(
    titleType: .titleCloseButton(title: "멤버십 안내"),
    message: "안내 문구입니다.",
    buttonType: .oneButton(buttonTitle: "확인", usage: .retailMembership01),
    popupPresentingViewController: self,
    cancelAction: nil,
    confirmAction: { print("확인") }
)
```

| 넘기는 값 | 확인 버튼 | option 보조 버튼 | cancel 보조 버튼 |
|---|---|---|---|
| `.default` (생략 시) | `btnFilledLarge01` primary01 | `btnOutlineLarge01` | `btnOutlineLarge06` |
| `.wholesaleMembership` | `btnFilledLarge02` primary gradient | `btnOutlineLarge01` | `btnOutlineLarge06` |
| `.retailMembership01` | `btnFilledLarge04` mbs01 | `btnOutlineLarge03` secondary01 | `btnOutlineLarge06` |
| `.retailMembership02` | `btnFilledLarge05` mbs gradient | `btnOutlineLarge03` secondary01 | `btnOutlineLarge06` |

### 3. 용도 — `cancelButtonType`

보조 버튼의 성격을 고릅니다. `cancel` 은 사용처와 무관하게 항상 회색(secondary04)입니다.

```swift
// 둘 다 선택지인 경우 → 테마색 outline
buttonType: .twoButton(confirmTitle: "옵션 A", cancelTitle: "옵션 B",
                       cancelButtonType: .option,
                       usage: .retailMembership01)

// 확인 / 취소인 경우 → 회색 outline
buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소",
                       cancelButtonType: .cancel,
                       usage: .retailMembership01)
```

### 4. 배치 — `axis`

```swift
buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "취소",
                       cancelButtonType: .cancel,
                       usage: .wholesaleMembership,
                       axis: .vertical)
```

`axis: .vertical` 이면 **확인 버튼이 위, 보조 버튼이 아래**로 자동 배치됩니다. 가로 배치(좌: 보조 / 우: 확인)와 순서가 반대인데 인자 순서는 그대로 두면 되고, 컴포넌트가 뒤집습니다. 콘텐츠 최대 높이도 132pt 기준으로 자동 재계산됩니다.

### 5. 표에 없는 조합이 필요할 때

`EBottomSheetButtonUsage` 는 enum 이 아니라 struct 이므로 호출부에서 바로 만들 수 있습니다. 디자인시스템 릴리즈를 기다릴 필요가 없습니다.

```swift
let promotionUsage = EBottomSheetButtonUsage(
    confirmButtonStyle: .btnFilledLarge06,   // primary05
    optionButtonStyle: .btnOutlineLarge04    // secondary02
    // cancelButtonStyle 생략 시 .btnOutlineLarge06 (회색)
)

buttonType: .twoButton(confirmTitle: "확인", cancelTitle: "옵션",
                       cancelButtonType: .option,
                       usage: promotionUsage)
```

`EBottomSheetButtonStyle` 은 `btnFilledLarge01~06`, `btnOutlineLarge01~06` 전체를 받습니다. 자주 쓰게 되면 `static let` 으로 정식 사용처 승격을 요청해주세요.

### 6. SwiftUI

`DealiSheetView` 는 화면 위에 얹히는 오버레이라 `ZStack` + `DealiSheetState` 가 필요합니다.

```swift
struct MyView: View {
    @StateObject private var sheetState = DealiSheetState()

    var body: some View {
        ZStack(alignment: .bottom) {
            Button("바텀시트 열기") { sheetState.isPresented = true }

            DealiSheetView(
                title: "옵션 선택",
                showCloseButton: true,
                buttonType: .twoButton(confirmTitle: "확인",
                                       cancelTitle: "취소",
                                       cancelButtonType: .cancel,
                                       usage: .retailMembership01,
                                       axis: .vertical),
                onConfirm: { print("확인") },
                onCancel: { print("취소") }
            ) {
                Text("콘텐츠")
            }
            .environmentObject(sheetState)
        }
    }
}
```

`buttonType` 이 UIKit 과 **완전히 같은 타입**이라 화면을 SwiftUI 로 옮길 때 값을 그대로 옮기면 됩니다. 버튼 탭 시 시트가 먼저 닫히고 콜백이 실행되는 순서도 UIKit 과 동일합니다.

---

## 마이그레이션

빌드는 되지만 deprecation warning 이 붙습니다. Xcode fix-it 으로 일괄 치환 가능합니다.

| 기존 | 변경 |
|---|---|
| `cancelButtonType: .btnOutlineLarge01` | `cancelButtonType: .option` |
| `cancelButtonType: .btnOutlineLarge06` | `cancelButtonType: .cancel` |

동작은 완전히 동일하고 이름만 "어떤 버튼 스타일인지"에서 "어떤 용도인지"로 바뀌었습니다. 사용처를 멤버십으로 바꿀 때 `.option` 이 알아서 맞는 색을 따라가는 게 이 변경의 이유입니다.

---

## 주요 변경 파일

**라이브러리**

- `Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheetButtonStyle.swift` **(신규)**
  - `EBottomSheetButtonStyle` — UIKit `DealiControl` 팩토리 ↔ SwiftUI `ButtonView.ButtonConfigStyle` 매핑의 단일 소스
  - `EBottomSheetButtonUsage` (struct), `EBottomSheetButtonAxis`
  - `DealiBottomSheet.swift` 에서 옮겨온 `EBottomSheetButtonType`, `EBottomSheetCancelButtonType` (동일 모듈 내 이동이라 공개 API 변화 없음)
- `Sources/DealiDesignKit/Components/BottomSheet/DealiBottomSheet.swift`
  - `buttonContainerView()` axis 분기. 상하 배치에서는 두 버튼이 stack 전체 높이를 채우려 해 제약이 충돌하므로 `top.bottom.equalToSuperview()` 를 걸지 않고 버튼 intrinsic height 에 맡깁니다
  - 확인 버튼도 usage 기반 생성으로 바꿔 보조 버튼과 대칭이 됩니다 (기존에는 확인만 하드코딩)
  - 중복 상수 `74.0` 2곳 → `EBottomSheetButtonType.contentHeight`, `!= .hidden` 4곳 → `isHidden`
- `Sources/DealiDesignKit/SwiftUIComponents/BottomSheet/SwiftUIView.swift`
  - `DealiSheetView` 에 `buttonType` / `onConfirm` / `onCancel` 추가 (전부 기본값 있어 기존 호출부 호환)

**SampleApp**

- `BottomSheetPopupTestViewController` — 사용처 5종 x 조합 5종 트리거 추가. 기존 `.oneButton` / `.twoButton` 호출부는 하위 호환 회귀 케이스로 그대로 남겼습니다
- `BottomSheetTestView.swift` **(신규)** — SwiftUI 데모. `FullSwiftUIBaseView` 와 `hasSwiftUISample` 양쪽에 등록

