### PR TITLE
[MP-7084] iOS 26 키보드 accessory view 이음새 처리

### DIFF
--- a/Sources/DealiDesignKit/Components/CountStepper/DealiCountStepper.swift
+++ b/Sources/DealiDesignKit/Components/CountStepper/DealiCountStepper.swift
@@ -124,10 +124,8 @@ public class DealiCountStepper: UIView {
         }
         
         let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0))
-        keyboardAccessoryView.do {
-            $0.backgroundColor = .g20
-        }
-        
+        keyboardAccessoryView.setKeyboardAccessoryStyle()
+
         keyboardAccessoryView.addSubview(self.closeButton)
         self.closeButton.then {
             $0.title = "닫기"

--- a/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
+++ b/Sources/DealiDesignKit/Components/SearchInput/DealiSearchInput.swift
@@ -130,10 +130,8 @@ public final class DealiSearchInput: UIView {
             guard let keyboardCloseButtonString = self.keyboardCloseButtonString else { return }
             
             let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0))
-            keyboardAccessoryView.do {
-                $0.backgroundColor = .g20
-            }
-            
+            keyboardAccessoryView.setKeyboardAccessoryStyle()
+
             let keyboardCloseButton = DealiControl.btnTextSmall04()
             keyboardAccessoryView.addSubview(keyboardCloseButton)
             keyboardCloseButton.then {

--- a/Sources/DealiDesignKit/Components/TextField/TextArea/DealiTextArea.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextArea/DealiTextArea.swift
@@ -239,10 +239,9 @@ public final class DealiTextArea: UIView, DealiTextField {
         didSet {
             guard let keyboardCloseButtonString = self.keyboardCloseButtonString else { return }
             
-            let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0)).then {
-                $0.backgroundColor = .g20
-            }
-            
+            let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0))
+            keyboardAccessoryView.setKeyboardAccessoryStyle()
+
             let keyboardCloseButton = DealiControl.btnTextSmall04()
             keyboardAccessoryView.addSubview(keyboardCloseButton)
             keyboardCloseButton.then {

--- a/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
+++ b/Sources/DealiDesignKit/Components/TextField/TextInputs/DealiTextInput.swift
@@ -243,10 +243,9 @@ open class DealiTextInput: UIView, DealiTextField {
         didSet {
             guard let keyboardCloseButtonString = self.keyboardCloseButtonString else { return }
             
-            let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0)).then {
-                $0.backgroundColor = .g20
-            }
-            
+            let keyboardAccessoryView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44.0))
+            keyboardAccessoryView.setKeyboardAccessoryStyle()
+
             let keyboardCloseButton = DealiControl.btnTextSmall04()
             keyboardAccessoryView.addSubview(keyboardCloseButton)
             keyboardCloseButton.then {

--- a/Sources/DealiDesignKit/Utils/Extensions/UIKit+Extension/UIView+Extension.swift
+++ b/Sources/DealiDesignKit/Utils/Extensions/UIKit+Extension/UIView+Extension.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import SwiftUI
+import Then
+import SnapKit
 
 extension UIView {
     
@@ -24,6 +26,37 @@ extension UIView {
         self.clipsToBounds = true
     }
     
+    /**
+     설명: 키보드 inputAccessoryView 배경을 iOS 26 키보드 형태에 맞게 세팅합니다.
+     */
+    func setKeyboardAccessoryStyle() {
+        self.backgroundColor = .g20
+
+        // iOS 26부터 키보드 패널이 상단 모서리를 라운드로 깎아, 각진 accessory view와 만나는
+        // 좌우 이음새에 앱 배경이 드러나는 쐐기가 생긴다.
+        // 상단 모서리를 키보드와 같은 곡률로 맞추고, 하단으로 넘치는 view를 키보드 뒤에 깔아
+        // 그 쐐기까지 같은 배경색으로 채운다.
+        guard #available(iOS 26.0, *) else { return }
+
+        // 키보드 패널 상단 모서리 곡률. 시뮬레이터 렌더링을 픽셀 측정해 맞춘 값.
+        let keyboardCornerRadius: CGFloat = 26.5
+
+        self.clipsToBounds = false
+        self.layer.cornerRadius = keyboardCornerRadius
+        self.layer.cornerCurve = .continuous
+        self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+
+        let overflowView = UIView()
+        self.addSubview(overflowView)
+        overflowView.then {
+            $0.backgroundColor = .g20
+        }.snp.makeConstraints {
+            $0.top.equalTo(self.snp.bottom)
+            $0.left.right.equalToSuperview()
+            $0.height.equalTo(keyboardCornerRadius)
+        }
+    }
+
     func toSwiftUIView() -> some View {
         return UIViewWrapper(uiView: self)
     }


### PR DESCRIPTION
## 요약

iOS 26에서 `keyboardCloseButtonString`으로 붙는 키보드 `닫기` 바가 키보드와 이음새가 어긋나는 문제를 수정합니다.

관련 컴포넌트 4개(`DealiTextInput`, `DealiTextArea`, `DealiSearchInput`, `DealiCountStepper`)가 동일한 코드를 복제하고 있어 함께 처리했습니다.

## 문제

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/before-seam.png" width="600">

이음새 좌측을 확대하면 이렇습니다. `닫기` 바 아래, 키보드가 깎아낸 코너 자리에 앱 배경(흰색)이 그대로 드러납니다.

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/before-seam-zoom.png" width="300">

## 원인

accessory view가 없는 상태로 키보드만 띄워봤습니다.

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/keyboard-only.png" width="600">

**iOS 26부터 키보드 패널 자체가 상단 모서리를 라운드로 깎습니다.** accessory view 유무와 무관한 키보드 고유 형태입니다.

여기에 기존 `닫기` 바는 모서리가 각진 full-bleed 사각형이라, 바의 각진 하단과 키보드의 둥근 상단이 만나는 좌우에 약 29pt × 21pt짜리 쐐기가 생깁니다. iOS 25 이하는 키보드 상단이 각져 있어 드러나지 않던 문제입니다.

참고로 **너비나 간격 문제가 아닙니다.** 실측 결과 바 하단 y=1667, 키보드 상단 y=1668로 틈은 0px였습니다.

## 해결

1. accessory view 상단 모서리를 키보드와 같은 곡률로 맞춤 — `cornerRadius 26.5`, `cornerCurve .continuous`
2. 하단으로 넘치는 view를 깔아 쐐기를 같은 배경색으로 채움 — accessory view의 subview는 키보드 **뒤에** 그려지므로, 키보드에 가려지고 코너로 깎인 부분에서만 드러납니다

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/after-seam.png" width="600">

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/after-seam-zoom.png" width="300">

이음새 좌측 y=1690 라인 픽셀:

| | x=0 | x=29 |
|---|---|---|
| 수정 전 | `(255,255,255)` 흰색 | 키보드 회색 |
| 수정 후 | `(235,238,246)` `.g20` | 키보드 회색 |

### 곡률 값 근거

눈대중이 아니라 스크린샷 픽셀에서 키보드 코너를 측정해 맞췄습니다.

- 키보드 상단 코너를 원으로 피팅 → R ≈ 79.6px = **26.5pt** (@3x)
- `.circular`로는 키보드보다 약 10% 타이트해서 `.continuous`(스퀘어클)로 변경
- 최종 확인: 각 패널 상단으로부터 같은 거리에서 곡선의 x 좌표가 1px 이내로 일치

| 패널 상단 기준 거리 | dy=3 | dy=9 | dy=14 | dy=19 | dy=24 |
|---|---|---|---|---|---|
| `닫기` 바 | 59 | 42 | 33 | 27 | 22 |
| 키보드 | 60 | 43 | 34 | 28 | 23 |

## 검증

**iPhone 17 / iOS 26.1** — `DealiTextInput`(한글 키보드), `DealiCountStepper`(숫자 키보드) 이음새 픽셀까지 확인. 쐐기 없음.

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/after-countstepper.png" width="600">

**iPhone 16 / iOS 18.3.1** — `guard #available(iOS 26.0, *)`로 early return 하므로 라운드도 overflow view도 생성되지 않습니다. 기존과 픽셀 단위로 동일합니다.

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7084-screenshots/ios18-no-regression.png" width="600">

`x=1` 세로 라인 스캔 결과 — 바 높이 132px(44pt), 틈 0px, 라운드 없음, overflow leak 없음.

| y | RGB | |
|---|---|---|
| ~1550 | `(255,255,255)` | 앱 배경 |
| 1551 | `(235,238,246)` | `.g20` 바 시작 |
| 1683 | `(209,212,217)` | 키보드 시작 |

빌드는 iOS 18.3, iOS 26.1 두 타겟 모두 통과했습니다.

## 확인 못 한 것

- **하드웨어 키보드 연결 시(iOS 26)**: 소프트 키보드 없이 accessory 바만 뜰 때 아래를 가려줄 키보드가 없어 26.5pt만큼 `.g20`이 더 내려갈 수 있습니다. Simulator 전역 설정을 바꿔야 해서 테스트하지 않았습니다. 실기기 블루투스 키보드로 확인 필요합니다.
- iPad 분할/플로팅 키보드도 같은 이유로 미확인입니다.
- 26.5pt는 iPhone 17 기준 측정값입니다. 시스템 상수로 보이지만 다른 기기에서 다르면 조정이 필요할 수 있습니다.

## 참고

- `DealiCountStepper`의 닫기 버튼만 우측 offset이 0(나머지 3개는 -12.0)인 기존 불일치는 이번 범위에서 제외했습니다.
- accessory view 생성 코드가 여전히 4곳에 복제돼 있습니다. 이번엔 라운드 처리만 헬퍼로 모았고, 공용 뷰로 묶는 건 별도 작업이 필요합니다.
- PR 본문 이미지는 `docs/MP-7084-screenshots` orphan 브랜치에 있습니다. 소스 브랜치에는 포함되지 않으며, 머지 후 삭제해도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
