### PR TITLE
[MP-7116] DealiAlert max width 지정 및 버튼 스타일 커스텀 지원

### DIFF
--- a/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/AlertTestViewController.swift
+++ b/DealiDesignSystemSampleApp/DealiDesignSystemSampleApp/Sub/UIKitBase/3. Molecule/AlertTestViewController.swift
@@ -105,6 +105,15 @@ class AlertTestViewController: UIViewController {
         }.snp.makeConstraints {
             $0.left.right.equalToSuperview()
         }
+        
+        let alertButton06 = DealiControl.btnOutlineLarge01()
+        contentStackView.addArrangedSubview(alertButton06)
+        alertButton06.then {
+            $0.title = "버튼 스타일 변경 팝업"
+            $0.addTarget(self, action: #selector(alertButton06Pressed), for: .touchUpInside)
+        }.snp.makeConstraints {
+            $0.left.right.equalToSuperview()
+        }
     }
 }
 
@@ -127,10 +136,35 @@ extension AlertTestViewController {
         DealiAlert.show(message: "Alert 테스트중",
                         cancelButtonTitle: "취소",
                         confirmButtonTitle: "확인\n확인\n확인",
+                        buttonStyle: .init(makeConfirmButton: { DealiControl.btnFilledMedium02() }),
                         heightRatio: 0.9,
                         alertPresentingViewController: self,
                         cancelAction: nil, confirmAction: nil)
         
+    }
+    
+    @objc func alertButton06Pressed() {
+        debugPrint("alertButton06Pressed")
+        
+        if isSwiftUI {
+            AlertView(title: "버튼 스타일 변경",
+                      message: "buttonStyle로 취소/확인 버튼 스타일을 바꾼 팝업입니다.",
+                      confirm: .init(title: "확인"),
+                      cancel: .init(title: "취소"),
+                      buttonStyle: .init(cancel: .btnOutlineMedium03, confirm: .btnFilledMedium06))
+            .show(self)
+            return
+        }
+        
+        DealiAlert.show(title: "버튼 스타일 변경",
+                        message: "buttonStyle로 취소/확인 버튼 스타일을 바꾼 팝업입니다.",
+                        cancelButtonTitle: "취소",
+                        confirmButtonTitle: "확인",
+                        buttonStyle: .init(makeCancelButton: { DealiControl.btnOutlineMedium03() },
+                                           makeConfirmButton: { DealiControl.btnFilledMedium06() }),
+                        alertPresentingViewController: self,
+                        cancelAction: nil,
+                        confirmAction: nil)
     }
     
     @objc func alertButton02Pressed() {

--- a/Sources/DealiDesignKit/Components/Alert/DealiAlert.swift
+++ b/Sources/DealiDesignKit/Components/Alert/DealiAlert.swift
@@ -8,6 +8,25 @@
 import UIKit
 
 /**
+ 설명: Alert 취소/확인 버튼의 스타일을 정하는 값
+ */
+public struct DealiAlertButtonStyle {
+    /// 취소 버튼 생성
+    public var makeCancelButton: () -> ClickableUnitButtonComponent
+    /// 확인 버튼 생성
+    public var makeConfirmButton: () -> ClickableUnitButtonComponent
+    
+    public init(makeCancelButton: @escaping () -> ClickableUnitButtonComponent = { DealiControl.btnOutlineMedium01() },
+                makeConfirmButton: @escaping () -> ClickableUnitButtonComponent = { DealiControl.btnFilledMedium01() }) {
+        self.makeCancelButton = makeCancelButton
+        self.makeConfirmButton = makeConfirmButton
+    }
+    
+    /// 디자인시스템 기본 스타일
+    public static let `default` = DealiAlertButtonStyle()
+}
+
+/**
  디자인시스템 Alert 적용
  현제는 기본적으로 Title, Massge, 취소, 확인버튼만 존제하는 기본 Alert
  content 영역 이외의 영역 터치시 alert닫기 위해서는 closeAlertOnOutsideTouch = true 로 설정
@@ -20,12 +39,13 @@ public class DealiAlert: NSObject {
     
     // 1버튼 확인 버튼
     @discardableResult
-    public class func showConfirm(title: String? = nil, message: String, confirmButtonTitle: String?, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
+    public class func showConfirm(title: String? = nil, message: String, confirmButtonTitle: String?, buttonStyle: DealiAlertButtonStyle = .default, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
         
         return self.show(title: title,
                          message: message,
                          cancelButtonTitle: nil,
                          confirmButtonTitle: confirmButtonTitle,
+                         buttonStyle: buttonStyle,
                          closeAlertOnOutsideTouch: closeAlertOnOutsideTouch,
                          cancelActionOnOutsideTouch: cancelActionOnOutsideTouch,
                          alertPresentingViewController: alertPresentingViewController,
@@ -35,7 +55,7 @@ public class DealiAlert: NSObject {
     
     // 체크박스가 포함된 alert case
     @discardableResult
-    public class func showCheckBox(title: String? = nil, message: String, checkButtonTitle: String, cancelButtonTitle: String?, confirmButtonTitle: String?, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, cancelAction: ((Bool) -> Swift.Void)?, confirmAction: ((Bool) -> Swift.Void)?) -> DealiAlertViewController {
+    public class func showCheckBox(title: String? = nil, message: String, checkButtonTitle: String, cancelButtonTitle: String?, confirmButtonTitle: String?, buttonStyle: DealiAlertButtonStyle = .default, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, cancelAction: ((Bool) -> Swift.Void)?, confirmAction: ((Bool) -> Swift.Void)?) -> DealiAlertViewController {
         
         let checkBoxContainerView = UIView()
         
@@ -55,6 +75,7 @@ public class DealiAlert: NSObject {
             insertCustomView: checkBoxContainerView,
             cancelButtonTitle: cancelButtonTitle,
             confirmButtonTitle: confirmButtonTitle,
+            buttonStyle: buttonStyle,
             closeAlertOnOutsideTouch: closeAlertOnOutsideTouch,
             cancelActionOnOutsideTouch: cancelActionOnOutsideTouch,
             alertPresentingViewController: alertPresentingViewController,
@@ -71,7 +92,7 @@ public class DealiAlert: NSObject {
     
     // textLinkButton이 포함된 alert case
     @discardableResult
-    public class func showTextLink(title: String? = nil, message: String, textLinkButtonTitle: String, cancelButtonTitle: String?, confirmButtonTitle: String?, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?, textLinkAction: (() -> Swift.Void)?) -> DealiAlertViewController {
+    public class func showTextLink(title: String? = nil, message: String, textLinkButtonTitle: String, cancelButtonTitle: String?, confirmButtonTitle: String?, buttonStyle: DealiAlertButtonStyle = .default, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?, textLinkAction: (() -> Swift.Void)?) -> DealiAlertViewController {
         
         let textLinkContainerView = UIView()
         
@@ -88,6 +109,7 @@ public class DealiAlert: NSObject {
                                             insertCustomView: textLinkContainerView,
                                             cancelButtonTitle: cancelButtonTitle,
                                             confirmButtonTitle: confirmButtonTitle,
+                                            buttonStyle: buttonStyle,
                                             closeAlertOnOutsideTouch: closeAlertOnOutsideTouch,
                                             cancelActionOnOutsideTouch: cancelActionOnOutsideTouch,
                                             alertPresentingViewController: alertPresentingViewController,
@@ -106,7 +128,7 @@ public class DealiAlert: NSObject {
     }
     
     @discardableResult
-    public class func show(title: String? = nil, message: String? = nil, insertCustomView: UIView? = nil, cancelButtonTitle: String?, confirmButtonTitle: String?, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, audoDismissDuration: CGFloat? = nil, heightRatio: CGFloat = 0.7, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
+    public class func show(title: String? = nil, message: String? = nil, insertCustomView: UIView? = nil, cancelButtonTitle: String?, confirmButtonTitle: String?, buttonStyle: DealiAlertButtonStyle = .default, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, audoDismissDuration: CGFloat? = nil, heightRatio: CGFloat = 0.7, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
         
         var messageAttString: NSMutableAttributedString?
         if let message = message, message.trimming().isEmpty == false {
@@ -122,6 +144,7 @@ public class DealiAlert: NSObject {
                                           insertCustomView: insertCustomView,
                                           cancelButtonTitle: cancelButtonTitle,
                                           confirmButtonTitle: confirmButtonTitle,
+                                          buttonStyle: buttonStyle,
                                           closeAlertOnOutsideTouch: closeAlertOnOutsideTouch,
                                           cancelActionOnOutsideTouch: cancelActionOnOutsideTouch,
                                           audoDismissDuration: audoDismissDuration,
@@ -133,7 +156,7 @@ public class DealiAlert: NSObject {
     }
     
     @discardableResult
-    public class func showAttributedMessage(title: String? = nil, message: NSMutableAttributedString?, insertCustomView: UIView? = nil, cancelButtonTitle: String?, confirmButtonTitle: String?, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, audoDismissDuration: CGFloat? = nil, heightRatio: CGFloat = 0.7, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
+    public class func showAttributedMessage(title: String? = nil, message: NSMutableAttributedString?, insertCustomView: UIView? = nil, cancelButtonTitle: String?, confirmButtonTitle: String?, buttonStyle: DealiAlertButtonStyle = .default, closeAlertOnOutsideTouch: Bool = true, cancelActionOnOutsideTouch: Bool = false, audoDismissDuration: CGFloat? = nil, heightRatio: CGFloat = 0.7, alertPresentingViewController: UIViewController, cancelAction: (() -> Swift.Void)?, confirmAction: (() -> Swift.Void)?) -> DealiAlertViewController {
         
         let alertViewController = DealiAlertViewController()
         if let title = title {
@@ -148,6 +171,7 @@ public class DealiAlert: NSObject {
         alertViewController.insertCustomView = insertCustomView
         alertViewController.cancelButtonTitle = cancelButtonTitle
         alertViewController.confirmButtonTitle = confirmButtonTitle
+        alertViewController.buttonStyle = buttonStyle
         alertViewController.closeAlertOnOutsideTouch = closeAlertOnOutsideTouch
         alertViewController.cancelActionOnOutsideTouch = cancelActionOnOutsideTouch
         alertViewController.cancelAction = cancelAction
@@ -193,6 +217,8 @@ open class DealiAlertViewController: DealiAlertBaseViewController {
     
     /// 타이틀영역 높이
     public var titleContentHeight: CGFloat = 26.0
+    /// 취소/확인 버튼 스타일
+    public var buttonStyle: DealiAlertButtonStyle = .default
     
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -274,7 +300,7 @@ open class DealiAlertViewController: DealiAlertBaseViewController {
             }
             
             if self.shouldExposeCancelButton {
-                let cancelButton = DealiControl.btnOutlineMedium01()
+                let cancelButton = self.buttonStyle.makeCancelButton()
                 self.buttonStackView.addArrangedSubview(cancelButton)
                 cancelButton.then {
                     $0.title = self.cancelButtonTitle
@@ -286,7 +312,7 @@ open class DealiAlertViewController: DealiAlertBaseViewController {
             }
             
             if self.shouldExposeConfirmButton {
-                let confirmButton = DealiControl.btnFilledMedium01()
+                let confirmButton = self.buttonStyle.makeConfirmButton()
                 self.buttonStackView.addArrangedSubview(confirmButton)
                 confirmButton.then {
                     $0.title = self.confirmButtonTitle

--- a/Sources/DealiDesignKit/Components/Alert/DealiAlertBaseViewController.swift
+++ b/Sources/DealiDesignKit/Components/Alert/DealiAlertBaseViewController.swift
@@ -12,6 +12,11 @@ open class DealiAlertBaseViewController: UIViewController {
     public let contentView = UIView()
     public let contentStackView = UIStackView()
     
+    /// alert content 영역의 최대 너비
+    public static let maxContentWidth: CGFloat = 360.0
+    /// alert content 영역의 좌우 최소 여백
+    public static let contentHorizontalPadding: CGFloat = 40.0
+    
     /// alert 최대 높이 값이 동적으로 정해질때의 최대 높이값을 정하는 비율값
     public var heightRatio: CGFloat = 0.7
     /// alert 최대 높이값이 정적으로 지정되야 할경우 세팅되는 높이값
@@ -71,10 +76,7 @@ open class DealiAlertBaseViewController: UIViewController {
         }
         let keyboardVisibleHeight = keyboardFrame.cgRectValue.height
         
-        self.contentView.snp.remakeConstraints {
-            $0.left.right.equalToSuperview().inset(40.0)
-            $0.centerY.equalToSuperview().offset(-keyboardVisibleHeight / 2)
-        }
+        self.remakeContentViewConstraints(keyboardVisibleHeight: keyboardVisibleHeight)
         self.view.layoutIfNeeded()
     }
     
@@ -84,24 +86,29 @@ open class DealiAlertBaseViewController: UIViewController {
             return
         }
         
-        self.contentView.snp.remakeConstraints {
-            $0.left.right.equalToSuperview().inset(40.0)
-            $0.centerY.equalToSuperview()
-        }
+        self.remakeContentViewConstraints()
         self.view.layoutIfNeeded()
+    }
+    
+    /// contentView는 기본적으로 좌우 여백 기준으로 너비가 늘어나고, `maxContentWidth`를 넘으면 그 값으로 고정된다
+    private func remakeContentViewConstraints(keyboardVisibleHeight: CGFloat = 0.0) {
+        self.contentView.snp.remakeConstraints {
+            $0.width.equalToSuperview().offset(-(Self.contentHorizontalPadding * 2.0)).priority(999.0)
+            $0.width.lessThanOrEqualTo(Self.maxContentWidth)
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(-keyboardVisibleHeight / 2.0)
+        }
     }
     
     open override func loadView() {
         super.loadView()
         
         self.view.addSubview(self.contentView)
-        self.contentView.then {
+        self.contentView.do {
             $0.backgroundColor = .primary04
             $0.setCornerRadius(10.0)
-        }.snp.makeConstraints {
-            $0.left.right.equalToSuperview().inset(40.0)
-            $0.centerY.equalToSuperview()
         }
+        self.remakeContentViewConstraints()
         
         self.contentView.addSubview(self.contentStackView)
         self.contentStackView.then {
@@ -122,7 +129,7 @@ open class DealiAlertBaseViewController: UIViewController {
         }
     }
     
-    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
         guard let touch = touches.first, self.contentView.bounds.contains(touch.location(in: self.contentView)) == false, self.closeAlertOnOutsideTouch == true else { return }
         

--- a/Sources/DealiDesignKit/SwiftUIComponents/Alert/AlertView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/Alert/AlertView.swift
@@ -92,7 +92,8 @@ public struct AlertView: View {
                 .onTapGesture { dismissAlert() }
             
             alertContent
-                .padding(.horizontal, 40)
+                .frame(maxWidth: DealiAlertBaseViewController.maxContentWidth)
+                .padding(.horizontal, DealiAlertBaseViewController.contentHorizontalPadding)
         }
         .onAppear { showAlert() }
     }

--- a/Sources/DealiDesignKit/SwiftUIComponents/Alert/AlertView.swift
+++ b/Sources/DealiDesignKit/SwiftUIComponents/Alert/AlertView.swift
@@ -21,25 +21,47 @@ public struct AlertButton {
     }
 }
 
+/**
+ 설명: Alert 취소/확인 버튼의 스타일을 정하는 값
+ */
+public struct AlertButtonStyle {
+    /// 취소 버튼 스타일
+    public var cancel: ButtonView.ButtonConfigStyle
+    /// 확인 버튼 스타일
+    public var confirm: ButtonView.ButtonConfigStyle
+    
+    public init(cancel: ButtonView.ButtonConfigStyle = .btnOutlineMedium01,
+                confirm: ButtonView.ButtonConfigStyle = .btnFilledLarge01) {
+        self.cancel = cancel
+        self.confirm = confirm
+    }
+    
+    /// 디자인시스템 기본 스타일
+    public static let `default` = AlertButtonStyle()
+}
+
 public struct AlertViewModel {
     public var title: String?
     public var message: String?
     public var checkbox: CheckboxView?
     public var confirm: AlertButton?
     public var cancel: AlertButton?
+    public var buttonStyle: AlertButtonStyle
 
     public init(
         title: String? = nil,
         message: String,
         checkbox: CheckboxView? = nil,
         confirm: AlertButton? = nil,
-        cancel: AlertButton? = nil
+        cancel: AlertButton? = nil,
+        buttonStyle: AlertButtonStyle = .default
     ) {
         self.title = title
         self.message = message
         self.checkbox = checkbox
         self.confirm = confirm
         self.cancel = cancel
+        self.buttonStyle = buttonStyle
     }
 }
 
@@ -67,12 +89,14 @@ public struct AlertView: View {
                 message: String,
                 checkbox: CheckboxView? = nil,
                 confirm: AlertButton? = nil,
-                cancel: AlertButton? = nil) {
+                cancel: AlertButton? = nil,
+                buttonStyle: AlertButtonStyle = .default) {
         let viewModel = AlertViewModel(title: title,
                                        message: message,
                                        checkbox: checkbox,
                                        confirm: confirm,
-                                       cancel: cancel)
+                                       cancel: cancel,
+                                       buttonStyle: buttonStyle)
         self.init(viewModel: viewModel)
     }
     
@@ -150,7 +174,7 @@ public struct AlertView: View {
         Spacer().frame(height: 24.0)
         HStack(spacing: 10.0) {
             if let cancel = viewModel.cancel {
-                ButtonView(type: .btnOutlineMedium01,
+                ButtonView(type: viewModel.buttonStyle.cancel,
                            title: cancel.title) {
                     cancel.action()
                     dismissAlert()
@@ -158,7 +182,7 @@ public struct AlertView: View {
             }
             
             if let confirm = viewModel.confirm {
-                ButtonView(type: .btnFilledLarge01,
+                ButtonView(type: viewModel.buttonStyle.confirm,
                            title: confirm.title) {
                     confirm.action()
                     dismissAlert()


### PR DESCRIPTION
## 요약

`DealiAlert`에 두 가지를 적용합니다.

1. content 너비 상한 `360` 지정
2. 취소/확인 버튼 스타일을 호출부에서 바꿀 수 있도록 개방

두 변경 모두 기본 동작이 기존과 같습니다. 앱 레포 호출부 207곳(`show` 117, `showConfirm` 83, `showCheckBox` 3, `showTextLink` 3, `showAttributedMessage` 1)은 수정 없이 그대로 컴파일됩니다.

## 1. max width 360

기존에는 좌우 40 padding만으로 너비를 잡아서 화면이 넓어지면 alert도 계속 넓어졌습니다. iPad Pro 11(834pt)에서 754pt까지 늘어납니다.

좌우 40 여백 기준으로 늘어나되 360을 상한으로 걸었습니다.

```swift
$0.width.equalToSuperview().offset(-(Self.contentHorizontalPadding * 2.0)).priority(999.0)
$0.width.lessThanOrEqualTo(Self.maxContentWidth)
$0.centerX.equalToSuperview()
$0.centerY.equalToSuperview().offset(-keyboardVisibleHeight / 2.0)
```

`999`는 "여백 기준으로 최대한 늘어나되 360 상한에는 양보한다"는 의도입니다. 라벨의 기본 compression resistance(750)보다 높게 둬서 텍스트가 alert을 벌리지 못하게 했습니다.

iPad Pro 11에서 화면 너비 834pt 중 360pt만 차지합니다.

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7116-screenshots/after-maxwidth-ipad.png" width="700">

`loadView`, 키보드 노출, 키보드 숨김 세 곳에 `left/right.inset(40.0)`이 중복돼 있었어서 `remakeContentViewConstraints(keyboardVisibleHeight:)` 하나로 합쳤습니다.

SwiftUI `AlertView`도 같은 상한을 적용했습니다. `.padding`이 바깥이라 제안 너비에서 좌우 40을 먼저 뺀 뒤 `frame(maxWidth:)`가 360으로 자릅니다. 결과는 UIKit과 동일한 `min(화면너비 - 80, 360)`입니다.

```swift
alertContent
    .frame(maxWidth: DealiAlertBaseViewController.maxContentWidth)
    .padding(.horizontal, DealiAlertBaseViewController.contentHorizontalPadding)
```

## 2. buttonStyle

기존에는 `loadView`에서 `DealiControl.btnOutlineMedium01()` / `btnFilledMedium01()`을 지역 변수로 만들어서 호출부에서 바꿀 방법이 없었습니다. `show`가 프로퍼티를 세팅한 직후 `present`를 호출하고 그 시점에 `loadView`가 돌기 때문에, 리턴된 VC를 받아서 바꾸는 방식도 이미 늦습니다. 그래서 파라미터로 받도록 했습니다.

`DealiControl.btnXxx()` 팩토리 150개가 전부 `ClickableUnitButtonComponent`를 반환해서, 팩토리 클로저를 그대로 받습니다.

```swift
public struct DealiAlertButtonStyle {
    public var makeCancelButton: () -> ClickableUnitButtonComponent
    public var makeConfirmButton: () -> ClickableUnitButtonComponent

    public init(makeCancelButton: @escaping () -> ClickableUnitButtonComponent = { DealiControl.btnOutlineMedium01() },
                makeConfirmButton: @escaping () -> ClickableUnitButtonComponent = { DealiControl.btnFilledMedium01() }) { ... }

    public static let `default` = DealiAlertButtonStyle()
}
```

`DealiAlert`의 5개 함수에 `buttonStyle: DealiAlertButtonStyle = .default`를 `confirmButtonTitle` 뒤에 추가했습니다. 두 파라미터 모두 기본값이 있어서 바꾸고 싶은 쪽만 넘기면 됩니다.

```swift
// 확인 버튼만 변경
buttonStyle: .init(makeConfirmButton: { DealiControl.btnFilledMedium06() })
```

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7116-screenshots/after-buttonstyle-uikit.png" width="700">

SwiftUI `AlertView`도 열었습니다. 여기는 `ButtonView.ButtonConfigStyle` enum이 이미 150개 케이스를 갖고 있어서 클로저 대신 enum을 받습니다.

```swift
AlertView(title: "버튼 스타일 변경",
          message: "…",
          confirm: .init(title: "확인"),
          cancel: .init(title: "취소"),
          buttonStyle: .init(cancel: .btnOutlineMedium03, confirm: .btnFilledMedium06))
```

<img src="https://raw.githubusercontent.com/dealicious-inc/ssm-mobile-ios-design-system/docs/MP-7116-screenshots/after-buttonstyle-swiftui.png" width="700">

샘플앱 Alert 화면에 `버튼 스타일 변경 팝업` 케이스를 UIKit/SwiftUI 양쪽에 추가했습니다.

## 확인한 내용

iPad Pro 11-inch(M4) 시뮬레이터에서 UIKit alert 5종(2버튼, 1버튼, check box, Text link, Text Input)과 SwiftUI alert을 확인했습니다.

- 전 케이스 너비 360 고정, 기본 버튼 스타일 회귀 없음
- Text Input 케이스에서 키보드 올렸을 때도 360 유지 + 위로 이동 정상
- 시뮬레이터 로그에 Auto Layout 제약 충돌 없음
- `buttonStyle`을 한쪽만 지정하는 형태 4가지 모두 컴파일 확인

## 주의해서 봐야 할 부분

- `width <= 360`이 required 제약입니다. `insertCustomView`로 넘기는 뷰에 360을 넘는 **고정 width 제약**이 있으면 충돌합니다. 앱 레포에서 `insertCustomView`를 쓰는 3곳(`DocumentUploadGuideAlert` 2곳, `SomeBalanceManageGuideAlertView`)을 확인했고 고정 width는 없었습니다.
- 너비가 줄어드니 같은 문구가 더 여러 줄로 감깁니다. iPad와 가로 모드에서 alert이 이전보다 세로로 길어집니다. `heightRatio` 0.7 상한과 스크롤은 그대로 동작합니다.
- SwiftUI 확인 버튼 기본값이 `.btnFilledLarge01`인데 UIKit은 `btnFilledMedium01`입니다. **원래부터 어긋나 있던 부분**이고, 임의로 맞추면 SwiftUI Alert을 쓰는 화면들의 버튼 높이가 조용히 바뀌기 때문에 기존 값을 유지했습니다. 의도된 차이가 아니라면 별도로 맞추면 좋겠습니다.
- `DealiAlertButtonStyle`과 `AlertButtonStyle`을 각각 `DealiAlert.swift` / `AlertView.swift` 안에 뒀습니다. 별도 파일로 빼는 게 좋다면 옮기겠습니다.

## Merge 전 필요한 작업

- 버전 태그 생성. 앱 레포가 `exact: "2.67.5"`로 핀하고 있어서 태그 후 앱에서 핀을 올려야 반영됩니다.

## 이번 범위에서 제외한 것

- `updateContainerViewHeight`의 `alertMaxHeight`가 `UIScreen.main.bounds.size.height`를 씁니다. iPad Split View처럼 앱 화면이 스크린보다 작을 때 최대 높이가 실제보다 크게 잡힙니다. 기존 사항이라 손대지 않았습니다.
- `showAttributedMessage`의 파라미터가 13개까지 늘었습니다. config 기반 API로 정리하려면 기존 함수를 deprecated로 남기고 점진적으로 이관하는 별도 티켓이 맞다고 봅니다.
